### PR TITLE
refactor(major): Overhaul the components, introduce testing APIs

### DIFF
--- a/addon-test-support/pages/-private/base-pop-menu.js
+++ b/addon-test-support/pages/-private/base-pop-menu.js
@@ -6,9 +6,7 @@ import { find } from 'ember-native-dom-helpers';
 
 import {
   attribute,
-  clickable,
-  hasClass,
-  triggerable
+  hasClass
 } from 'ember-cli-page-object';
 
 /**

--- a/addon-test-support/pages/ice-dropdown.js
+++ b/addon-test-support/pages/ice-dropdown.js
@@ -1,8 +1,8 @@
 import { clickable } from 'ember-cli-page-object';
 
-import BasePopoverPage from './utils/base-popover';
+import BasePopMenuPage from './-private/base-pop-menu';
 
-export default BasePopoverPage.extend({
+export default BasePopMenuPage.extend({
   trigger: {
     open: clickable(),
     close: clickable()

--- a/addon-test-support/pages/ice-dropdown.js
+++ b/addon-test-support/pages/ice-dropdown.js
@@ -1,0 +1,10 @@
+import { clickable } from 'ember-cli-page-object';
+
+import BasePopoverPage from './utils/base-popover';
+
+export default BasePopoverPage.extend({
+  trigger: {
+    open: clickable(),
+    close: clickable()
+  }
+});

--- a/addon-test-support/pages/ice-popover.js
+++ b/addon-test-support/pages/ice-popover.js
@@ -1,0 +1,19 @@
+import { clickable } from 'ember-cli-page-object';
+
+import BasePopoverPage from './utils/base-popover';
+
+export default BasePopoverPage.extend({
+  trigger: {
+    open: clickable(),
+    close: clickable()
+  },
+
+  content: {
+    /**
+     * Scope for the header of the popover if it exists
+     */
+    header: {
+      scope: 'header'
+    }
+  }
+});

--- a/addon-test-support/pages/ice-popover.js
+++ b/addon-test-support/pages/ice-popover.js
@@ -1,8 +1,8 @@
 import { clickable } from 'ember-cli-page-object';
 
-import BasePopoverPage from './utils/base-popover';
+import BasePopMenuPage from './-private/base-pop-menu';
 
-export default BasePopoverPage.extend({
+export default BasePopMenuPage.extend({
   trigger: {
     open: clickable(),
     close: clickable()

--- a/addon-test-support/pages/ice-sub-dropdown.js
+++ b/addon-test-support/pages/ice-sub-dropdown.js
@@ -1,8 +1,8 @@
 import { triggerable } from 'ember-cli-page-object';
 
-import BasePopoverPage from './utils/base-popover';
+import BasePopMenuPage from './-private/base-pop-menu';
 
-export default BasePopoverPage.extend({
+export default BasePopMenuPage.extend({
   trigger: {
     open: triggerable('mouseenter'),
     close: triggerable('mouseleave')

--- a/addon-test-support/pages/ice-sub-dropdown.js
+++ b/addon-test-support/pages/ice-sub-dropdown.js
@@ -1,0 +1,10 @@
+import { triggerable } from 'ember-cli-page-object';
+
+import BasePopoverPage from './utils/base-popover';
+
+export default BasePopoverPage.extend({
+  trigger: {
+    open: triggerable('mouseenter'),
+    close: triggerable('mouseleave')
+  }
+});

--- a/addon-test-support/pages/ice-tooltip-icon.js
+++ b/addon-test-support/pages/ice-tooltip-icon.js
@@ -1,0 +1,21 @@
+import { PageObject } from 'ember-classy-page-object';
+
+import TooltipPage from './ice-tooltip';
+
+import { find } from 'ember-native-dom-helpers';
+
+export default new PageObject({
+  /**
+   * Returns if this tooltip-icon is the specified icon
+   */
+  isIcon(icon) {
+    return find(this.scope).classList.contains(icon);
+  },
+
+  /**
+   * Scope tooltip associated with this tooltip-icon
+   */
+  tooltip: TooltipPage.extend({
+    scope: '[data-test-icon-tooltip]'
+  })
+});

--- a/addon-test-support/pages/ice-tooltip.js
+++ b/addon-test-support/pages/ice-tooltip.js
@@ -1,8 +1,8 @@
 import { triggerable } from 'ember-cli-page-object';
 
-import BasePopoverPage from './utils/base-popover';
+import BasePopMenuPage from './-private/base-pop-menu';
 
-export default BasePopoverPage.extend({
+export default BasePopMenuPage.extend({
   trigger: {
     open: triggerable('mouseenter'),
     close: triggerable('mouseleave')

--- a/addon-test-support/pages/ice-tooltip.js
+++ b/addon-test-support/pages/ice-tooltip.js
@@ -1,0 +1,10 @@
+import { triggerable } from 'ember-cli-page-object';
+
+import BasePopoverPage from './utils/base-popover';
+
+export default BasePopoverPage.extend({
+  trigger: {
+    open: triggerable('mouseenter'),
+    close: triggerable('mouseleave')
+  }
+});

--- a/addon-test-support/pages/utils/base-popover.js
+++ b/addon-test-support/pages/utils/base-popover.js
@@ -1,0 +1,85 @@
+import Ceibo from 'ceibo';
+
+import { PageObject } from 'ember-classy-page-object';
+
+import { find } from 'ember-native-dom-helpers';
+
+import {
+  attribute,
+  clickable,
+  hasClass,
+  triggerable
+} from 'ember-cli-page-object';
+
+/**
+ * Base test page-object for ice-tooltip, ice-popover, ice-dropdown, and ice-sub-dropdown.
+ * Allows testers to open ond close the popover and select its content, as well as check
+ * its current state.
+ */
+export default new PageObject({
+  /**
+   * Opens the popover using the method provided by the subclass on the trigger element
+   *
+   * @param {*} params - parameters to be passed forward
+   */
+  open(...params) {
+    return this.trigger.open(...params);
+  },
+
+  /**
+   * Closes the popover using the method provided by the subclass on the trigger element
+   *
+   * @param {*} params - parameters to be passed forward
+   */
+  close(...params) {
+    return this.trigger.close(...params);
+  },
+
+  /**
+   * Returns whether or not the popover is open
+   */
+  get isOpen() {
+    return this.content.isPresent;
+  },
+
+  /**
+   * Scope for the trigger element of the popover
+   */
+  trigger: {
+    resetScope: true,
+    get scope() {
+      const parent = find(Ceibo.parent(this).scope);
+
+      // The parent may not be rendered either, so we can only grab the ID if it exists
+      const parentId = parent ? parent.getAttribute('id') : 'unrendered';
+
+      return `[data-popover-trigger="${parentId}"]`;
+    },
+
+    /**
+     * Returns whether or not the trigger has been marked as active
+     */
+    isActive: hasClass('is-active')
+  },
+
+  /**
+   * Scope for the content element of the popover
+   */
+  content: {
+    resetScope: true,
+    get scope() {
+      const parent = find(Ceibo.parent(this).scope);
+
+      // The parent may not be rendered either, so we can only grab the ID if it exists
+      const parentId = parent ? parent.getAttribute('id') : 'unrendered';
+
+      return `[data-popover-content="${parentId}"]`;
+    },
+
+    /**
+     * Returns the placement of the popover's content based on its attribute
+     */
+    placement: attribute('x-placement')
+  }
+});
+

--- a/addon/components/-private/animated-popper.js
+++ b/addon/components/-private/animated-popper.js
@@ -10,7 +10,7 @@ import { unionOf } from 'ember-argument-decorators/types';
 
 import { scheduler as raf, Token } from 'ember-raf-scheduler';
 
-import layout from '../templates/components/animated-popper';
+import layout from '../../templates/components/animated-popper';
 
 function hasTransition(element) {
   const { transitionDuration } = window.getComputedStyle(element);

--- a/addon/components/-private/animated-popper.js
+++ b/addon/components/-private/animated-popper.js
@@ -57,7 +57,7 @@ export default class AnimatedPopperComponent extends Component {
   renderInPlace = false;
 
   /**
-   * The popper elment's class
+   * The popper element's class
    */
   @argument
   @type('string')
@@ -116,6 +116,7 @@ export default class AnimatedPopperComponent extends Component {
   }
 
   didInsertElement() {
+    // find the parent of the enclosing pop menu component
     this._target = this._parentFinder.parentNode.parentNode;
 
     addObserver(this, 'isOpen', this, this.isOpenDidChange);
@@ -159,7 +160,9 @@ export default class AnimatedPopperComponent extends Component {
    * Triggers when the popper has been inserted. Grabs the popper element to add animation event
    * handlers if needed, and propogates the API to the external context.
    *
-   * @param {PopperAPI} api - The API received from the underlying popper
+   * Note: The API itself is defined in ember-popper, which is an external library
+   *
+   * @param {PopperAPI} api - The API received from the underlying ember-popper component
    */
   @action
   registerAPI(api) {

--- a/addon/components/-private/base-pop-menu.js
+++ b/addon/components/-private/base-pop-menu.js
@@ -32,7 +32,7 @@ export default class BasePopMenuComponent extends Component {
   // ----- Arguments ------
 
   /**
-   * Used to determine the placement of the popover
+   * Used to determine the placement of the pop menu
    * Can choose between auto, top, right, bottom, left
    * Can also add -start or -end modifier
    */
@@ -68,7 +68,7 @@ export default class BasePopMenuComponent extends Component {
   // ----- Private Variables -----
 
   /**
-   * Tracks if the tooltip is open
+   * Tracks if the pop menu is open
    */
   @type('boolean')
   isOpen = false;

--- a/addon/components/-private/base-pop-menu.js
+++ b/addon/components/-private/base-pop-menu.js
@@ -27,7 +27,7 @@ function closest(node, selector) {
  * Adds the event listeners and data attributes that are common to all of the popover-like
  * components, and wraps all of their functionality.
  */
-export default class BasePopoverComponent extends Component {
+export default class BasePopMenuComponent extends Component {
   // ----- Arguments ------
 
   /**
@@ -81,7 +81,7 @@ export default class BasePopoverComponent extends Component {
   constructor() {
     super();
 
-    this._popperClass = `ice-base-popover ${this.class || ''} ${this.classNames.join(' ')}`;
+    this._popperClass = `ice-base-pop-menu ${this.class || ''} ${this.classNames.join(' ')}`;
 
     for (const binding of this.classNameBindings) {
       if (binding.value) {
@@ -201,7 +201,7 @@ export default class BasePopoverComponent extends Component {
   _handleBodyClick = ({ target }) => {
     if (this._isOpening) {
       this._isOpening = false;
-    } else if (closest(target, '.ice-base-popover') === null) {
+    } else if (closest(target, '.ice-base-pop-menu') === null) {
       // We do not want _removePopover to trigger when clicking inside of the popover.
       // Here we check whether the body click event was also a popover container click event.
       // We are comparing the click events because tracking the click element itself can

--- a/addon/components/animated-popper.js
+++ b/addon/components/animated-popper.js
@@ -1,0 +1,202 @@
+import Component from '@ember/component';
+import { run } from '@ember/runloop';
+import { addObserver, removeObserver } from '@ember/object/observers';
+
+import { action } from 'ember-decorators/object';
+import { tagName } from 'ember-decorators/component';
+
+import { argument, type } from 'ember-argument-decorators';
+import { unionOf } from 'ember-argument-decorators/types';
+
+import { scheduler as raf, Token } from 'ember-raf-scheduler';
+
+import layout from '../templates/components/animated-popper';
+
+function hasTransition(element) {
+  const { transitionDuration } = window.getComputedStyle(element);
+
+  return parseFloat(transitionDuration) > 0;
+}
+
+/**
+ * Private component used by ice-pop internally. This component handles the logic
+ * surrounding animation, including determining if animations should happen at all.
+ */
+@tagName('')
+export default class AnimatedPopperComponent extends Component {
+  layout = layout;
+
+  // ----- Arguments ------
+
+  /**
+   * Whether or not the popper is open
+   */
+  @argument
+  @type('boolean')
+  isOpen = false;
+
+  /**
+   * Action sent when the popper has been added to the DOM, before animations
+   */
+  @argument
+  @type(unionOf(null, 'action'))
+  onOpen = null;
+
+  /**
+   * Action sent when the popper has been removed from the DOM, after animations
+   */
+  @argument
+  @type(unionOf(null, 'action'))
+  onClose = null;
+
+  /**
+   * Whether or not the popper should render in place or at the root level
+   */
+  @argument
+  @type('boolean')
+  renderInPlace = false;
+
+  /**
+   * The popper elment's class
+   */
+  @argument
+  @type('string')
+  popperClass = '';
+
+  /**
+   * The placement for the popper element
+   */
+  @argument
+  @type('string')
+  placement = 'auto';
+
+  // ----- Private Variables -----
+
+  /**
+   * Whether or not the popper should be rendered in the DOM
+   */
+  @type('boolean')
+  renderInDOM = false;
+
+  /**
+   * Wether or not the popper should have the `is-visible` class, which will trigger animations
+   */
+  @type('boolean')
+  makeVisible = false;
+
+  /**
+   * RAF scheduler token, used to cancel all active jobs
+   */
+  _token = new Token();
+
+  /**
+   * Empty text node used to find the true parent element for this component
+   */
+  _parentFinder = document.createTextNode('');
+
+  /**
+   * The target element that the popper will position itself based on
+   */
+  _target = null;
+
+  /**
+   * The popper element, stored in order to add and remove event handlers for transitions
+   */
+  _animatedElement = null;
+
+  /**
+   * Whether or not the current popper has a transition duration > 0
+   */
+  _hasTransition = false;
+
+  constructor() {
+    super(...arguments);
+
+    this.isOpenDidChange();
+  }
+
+  didInsertElement() {
+    this._target = this._parentFinder.parentNode.parentNode;
+
+    addObserver(this, 'isOpen', this, this.isOpenDidChange);
+  }
+
+  willDestroy() {
+    raf.forget(this._token);
+
+    removeObserver(this, 'isOpen', this, this.isOpenDidChange);
+  }
+
+  /**
+   * Observer for whenever isOpen changes, toggling the state of the popper. Because
+   * animations can take some time to finalize, this toggle can happen many times between
+   * states, which is why this must be an observer in 1.11 (it is not tied directly to the DOM)
+   */
+  isOpenDidChange() {
+    if (this.get('isOpen') === true) {
+      this.set('renderInDOM', true);
+
+      raf.schedule('sync', () => {
+        this.set('makeVisible', true);
+      }, this._token);
+    } else {
+      this.set('makeVisible', false);
+
+      if (this._animatedElement && !this._hasTransition) {
+        // Use RAF to ensure that if the isOpen has change multiple times, removal
+        // will happen _after_ state has completely settled. This is particularly
+        // important in tests
+        raf.schedule('affect', () => {
+          if (this.get('makeVisible') === false) {
+            run(() => this.finalizeClose());
+          }
+        }, this._token);
+      }
+    }
+  }
+
+  /**
+   * Triggers when the popper has been inserted. Grabs the popper element to add animation event
+   * handlers if needed, and propogates the API to the external context.
+   *
+   * @param {PopperAPI} api - The API received from the underlying popper
+   */
+  @action
+  registerAPI(api) {
+    this._animatedElement = api.popperElement;
+    this._hasTransition = hasTransition(this._animatedElement);
+
+    if (this._hasTransition) {
+      this._animatedElement.addEventListener('transitionend', this._transitionEndHandler);
+    }
+
+    this.sendAction('onOpen', api);
+  }
+
+  /**
+   * Triggers on finalizing the close, after all animations (if any) have settled. Tears down handlers
+   * and notifies the parent context that animations have finished.
+   */
+  finalizeClose() {
+    this.set('renderInDOM', false);
+
+    if (this._hasTransition) {
+      this._animatedElement.removeEventListener('transitionend', this._transitionEndHandler);
+    }
+
+    this._animatedElement = null;
+
+    this.sendAction('onClose');
+  }
+
+  // ----- Event Handlers -----
+
+  /**
+   * Handler for finalizing close on transitions ending
+   */
+  _transitionEndHandler = () => {
+    if (this.get('makeVisible') === false) {
+      this.finalizeClose();
+    }
+  }
+}

--- a/addon/components/ice-dropdown.js
+++ b/addon/components/ice-dropdown.js
@@ -1,18 +1,11 @@
-import { DEBUG } from '@glimmer/env';
+import { argument, type } from 'ember-argument-decorators';
 
-import Component from '@ember/component';
-import { run } from '@ember/runloop';
-import { guidFor } from '@ember/object/internals';
-
-import { argument, type, immutable } from 'ember-argument-decorators';
-import { unionOf } from 'ember-argument-decorators/types';
-
+import BasePopoverComponent from './utils/base-popover';
 import layout from '../templates/components/ice-dropdown';
 
 /**
- * Super simple dropdown component that uses popper.js. By default it targets its
- * parent element for placement and warps itself to the root of the DOM, but it
- * can also take a target selector as an option.
+ * Super simple dropdown component that uses popper.js. It targets its immediate parent
+ * element, and will open whenever that element is clicked.
  *
  * ```hbs
  * <div class="target">
@@ -42,28 +35,24 @@ import layout from '../templates/components/ice-dropdown';
  * <div class="target">
  *   Target text
  *   <div class="ice-dropdown-caret"></div>
- *   {{#ice-dropdown closeItems="false"}}
- *     By default, clicking any dropdown menu link will close the dropdown,
- *     but you can turn this off via closeItems="false" if you need to handle closing manually
+ *   {{#ice-dropdown}}
+ *     <a data-close>
+ *       Adding data-close to anything within the dropdown will cause
+ *       it to close when the item is clicked
+ *     </a>
  *   {{/ice-tooltip}}
  * </div>
- *
- * <div data-dropdown-target>
- *   Target text
- *   <div class="ice-dropdown-caret"></div>
- * </div>
- * {{#ice-dropdown target="[data-dropdown-target]"}}
- *   Dropdown with external target, should be a unique id or attribute
- * {{/ice-dropdown}}
  * ```
  */
-export default class IceDropdown extends Component {
+export default class IceDropdownComponent extends BasePopoverComponent {
   layout = layout
+
+  triggerEvent = 'click'
 
   // ----- Public Settings ------
 
   /**
-   * Used to determine the placement of the tooltip
+   * Used to determine the placement of the dropdown
    * Can choose between auto, top, right, bottom, left
    * Can also add -start or -end modifier
    */
@@ -71,213 +60,4 @@ export default class IceDropdown extends Component {
   @type('string')
   placement = 'bottom-start';
 
-  /**
-   * Selector or Element
-   */
-  @immutable
-  @argument
-  @type(unionOf(null, 'string', Element))
-  target = null;
-
-  @argument
-  @type('boolean')
-  renderInPlace = false;
-
-  /**
-   * Determines whether this dropdown should be triggered by hover on the target
-   */
-  @argument
-  @type('boolean')
-  isTriggeredOnHover = false;
-
-  /**
-   * By default a dropdown will add the [data-dropdown-close] attribute to all items
-   * in the dropdown list. If you instead need to do it manually for finer control, set to false.
-   */
-  @argument
-  @type('boolean')
-  closeItems = true;
-
-  // ----- Private Variables -----
-
-  /**
-   * Used to track if the tooltip is open and appended to the DOM
-   */
-  @type('boolean')
-  isOpen = false;
-
-  /**
-   * Used to track whether fade in/out animation should trigger
-   */
-  @type('boolean')
-  isShowing = false;
-
-  /**
-   * Used to store the popper element for adding/removing event listeners
-   */
-  _popperElement = null;
-
-  /**
-   * Used to target/select the popper element after it's been inserted
-   */
-  _popperId = `${guidFor(this)}_popper`;
-
-  /**
-   * Used to as a proxy to pass along the class of this component to the actual popper
-   */
-  _popperClass = '';
-
-  constructor() {
-    super();
-
-    this._popperClass = this.class;
-    this._popperClass += ` ${this.classNames.join(' ')}`;
-
-    for (const binding of this.classNameBindings) {
-      if (binding.value) {
-        this._popperClass += ` ${binding.value()}`;
-      }
-    }
-  }
-
-  didInsertElement() {
-    this.element.className = '';
-
-    let target = this.get('target') || this.element.parentNode;
-
-    if (typeof target === 'string') {
-      const nodes = document.querySelectorAll(target);
-
-      // TODO: Add an assertion that throws if more than one node exists
-      target = nodes[0];
-    }
-
-    this._target = target;
-
-    // Add initial dropdown placement to the target element so that it can apply
-    // any special styling based on the dropdown's direction.
-    this._target.setAttribute('dropdown-placement', this.get('placement'));
-    // Add toggle class to target element, for open/closed or any styling needs.
-    this._target.classList.add('ice-dropdown-toggle');
-
-    // Click handler is used by default, when isTriggeredOnHover is false
-    this._clickHandler = () => {
-      if (this.get('isOpen') === false) {
-        this._insertDropdown();
-      }
-    };
-
-    // Hover is used when isTriggeredOnHover is true
-    this._mouseEnterHandler = () => {
-      this._insertDropdown();
-
-      this._popperElement.addEventListener('mouseenter', this._mouseEnterHandler);
-      this._popperElement.addEventListener('mouseleave', this._mouseLeaveHandler);
-    };
-
-    this._mouseLeaveHandler = () => {
-      this._removeDropdown();
-    };
-
-    this._transitionEndHandler = () => {
-      if (this.get('isShowing') === false) {
-        run(() => this.set('isOpen', false));
-
-        this._popperElement.removeEventListener('transitionend', this._transitionEndHandler);
-
-        this._popperElement = null;
-
-        // remove body listener here instead of _removeDropdown, so we are sure
-        // the dropdown is actually closed first, otherwise a dropdown can be left
-        // open with no way to close
-        document.body.removeEventListener('click', this._handleBodyClick);
-
-        // Similarly, we don't want the active styling to change until the dropdown
-        // is actually closed
-        this._target.classList.remove('is-active');
-      }
-    };
-
-    this._handleBodyClick = (event) => {
-      // We do not want _removeDropdown to trigger yet when clicking inside of the dropdown.
-      // Here we check whether the body click event was also a dropdown container click event.
-      // We are comparing the click events because tracking the click element itself can
-      // be buggy if the content within the dropdown ever changes while its still open.
-      if (event !== this.eventClick) {
-        this._removeDropdown();
-      }
-      // We still want to allow purposeful closing of the dropdown from within,
-      // so this closes the dropdown if the click target has [data-dropdown-close]
-      // attribute, regardless of where it is in the dom.
-      // (This could be problematic in the future if we ever have the use case for
-      // multiple dropdowns open. This would close all of them at the same time.)
-      if (event.target.attributes['data-dropdown-close']) {
-        this._removeDropdown();
-      }
-    };
-
-    this._insertDropdown = () => {
-      // Schedule these separately so that the element gets fully attached by setting
-      // `isOpen` to true, and only _then_ setting `isShowing` to true, triggering the
-      // CSS transition
-      run(() => this.set('isOpen', true));
-
-      this._insertFrame = requestAnimationFrame(() => {
-        run(() => this.set('isShowing', true));
-      });
-
-      this._popperElement = document.getElementById(this._popperId);
-
-      this._popperElement.addEventListener('transitionend', this._transitionEndHandler);
-
-      // We are storing the click event that happens directly on the dropdown container
-      // so that we can later compare it to the body click for closing logistics
-      this._popperElement.addEventListener('click', (event) => {
-        this.eventClick = event;
-      });
-
-      document.body.addEventListener('click', this._handleBodyClick);
-
-      // Add is-active class to target element, for styling needs based on whether
-      // the dropdown is currently open
-      this._target.classList.add('is-active');
-
-      if (this.get('closeItems')) {
-        // This makes the assumption that actions are placed on anchor elements, not on the li
-        const dropdownItems = this._popperElement.querySelectorAll('.ice-dropdown-menu li a');
-        dropdownItems.forEach(function(item) {
-          item.setAttribute('data-dropdown-close', '');
-        });
-      }
-
-      // Add attribute used for tests, is not used in prod
-      if (DEBUG & this.get('isTriggeredOnHover')) {
-        this._popperElement.setAttribute('data-test-sub-dropdown', '');
-      } else if (DEBUG) {
-        this._popperElement.setAttribute('data-test-dropdown', '');
-      }
-    };
-
-    this._removeDropdown = () => {
-      run(() => this.set('isShowing', false));
-    };
-
-    if (this.get('isTriggeredOnHover')) {
-      this._target.addEventListener('mouseenter', this._mouseEnterHandler);
-      this._target.addEventListener('mouseleave', this._mouseLeaveHandler);
-    } else {
-      this._target.addEventListener('click', this._clickHandler);
-    }
-  }
-
-  willDestroyElement() {
-    cancelAnimationFrame(this._insertFrame);
-    if (!this.isTriggeredOnHover) {
-      this._target.removeEventListener('click', this._clickHandler);
-    } else {
-      this._target.removeEventListener('mouseenter', this._mouseEnterHandler);
-      this._target.removeEventListener('mouseleave', this._mouseLeaveHandler);
-    }
-    document.body.removeEventListener('click', this._handleBodyClick);
-  }
 }

--- a/addon/components/ice-dropdown.js
+++ b/addon/components/ice-dropdown.js
@@ -1,6 +1,6 @@
 import { argument, type } from 'ember-argument-decorators';
 
-import BasePopoverComponent from './utils/base-popover';
+import BasePopMenuComponent from './-private/base-pop-menu';
 import layout from '../templates/components/ice-dropdown';
 
 /**
@@ -44,7 +44,7 @@ import layout from '../templates/components/ice-dropdown';
  * </div>
  * ```
  */
-export default class IceDropdownComponent extends BasePopoverComponent {
+export default class IceDropdownComponent extends BasePopMenuComponent {
   layout = layout
 
   triggerEvent = 'click'

--- a/addon/components/ice-popover.js
+++ b/addon/components/ice-popover.js
@@ -1,18 +1,13 @@
-import { DEBUG } from '@glimmer/env';
-
-import Component from '@ember/component';
-import { run } from '@ember/runloop';
-import { guidFor } from '@ember/object/internals';
-
-import { argument, type, immutable } from 'ember-argument-decorators';
+import { argument, type } from 'ember-argument-decorators';
 import { unionOf } from 'ember-argument-decorators/types';
+
+import BasePopoverComponent from './utils/base-popover';
 
 import layout from '../templates/components/ice-popover';
 
 /**
- * Super simple popover component that uses popper.js. By default it targets its
- * parent element for placement and warps itself to the root of the DOM, but it
- * can also take a target selector as an option.
+ * Super simple popover component that uses popper.js. It targets its immediate parent
+ * element, and will open whenever that element is clicked.
  *
  * ```hbs
  * <div class="target">
@@ -43,21 +38,26 @@ import layout from '../templates/components/ice-popover';
  *   {{/ice-popover}}
  * </div>
  *
- * <div data-popover-target>
+* <div class="target">
  *   Target text
+ *   {{#ice-popover}}
+ *     <a data-close>
+ *       Adding data-close to anything within the popover will cause
+ *       it to close when the item is clicked
+ *     </a>
+ *   {{/ice-popover}}
  * </div>
- * {{#ice-popover target="[data-popover-target]"}}
- *   Popover with external target, should be a unique id or attribute
- * {{/ice-popover}}
  * ```
  */
-export default class IcePopover extends Component {
+export default class IcePopoverComponent extends BasePopoverComponent {
   layout = layout
 
-  // ----- Public Settings ------
+  triggerEvent = 'click'
+
+  // ----- Arguments ------
 
   /**
-   * Used to determine the placement of the tooltip
+   * Used to determine the placement of the popover
    * Can choose between auto, top, right, bottom, left
    * Can also add -start or -end modifier
    */
@@ -66,151 +66,11 @@ export default class IcePopover extends Component {
   placement = 'right-start'
 
   /**
-   * Selector or Element
+   * Title for the popover, if provided will include the header
+   * in the template. Defaults to nothing.
    */
-  @immutable
-  @argument
-  @type(unionOf(null, 'string', Element))
-  target = null;
-
   @argument
   @type(unionOf(null, 'string'))
-  popoverTitle = null;
+  popoverTitle = null
 
-  // ----- Private Variables -----
-
-  /**
-   * Used to track if the tooltip is open and appended to the DOM
-   */
-  @type('boolean')
-  isOpen = false;
-
-  /**
-   * Used to track whether fade in/out animation should trigger
-   */
-  @type('boolean')
-  isShowing = false;
-
-  /**
-   * Used to store the popper element for adding/removing event listeners
-   */
-  _popperElement = null;
-
-  /**
-   * Used to target/select the popper element after it's been inserted
-   */
-  _popperId = `${guidFor(this)}_popper`;
-
-  /**
-   * Used to as a proxy to pass along the class of this component to the actual popper
-   */
-  _popperClass = '';
-
-  constructor() {
-    super();
-
-    this._popperClass = this.class || '';
-    this._popperClass += ` ${this.classNames.join(' ')}`;
-
-    for (const binding of this.classNameBindings) {
-      if (binding.value) {
-        this._popperClass += ` ${binding.value()}`;
-      }
-    }
-  }
-
-  didInsertElement() {
-    this.element.className = '';
-
-    let target = this.get('target') || this.element.parentNode;
-
-    if (typeof target === 'string') {
-      const nodes = document.querySelectorAll(target);
-
-      // TODO: Add an assertion that throws if more than one node exists
-      target = nodes[0];
-    }
-
-    this._target = target;
-
-    this._clickHandler = () => {
-      if (this.get('isOpen') === false) {
-        this._insertPopover();
-      }
-    };
-
-    // Determines whether or not a body click should close the currently open popover
-    this._handleBodyClick = (event) => {
-      // We do not want _removePopover to trigger when clicking inside of the popover.
-      // Here we check whether the body click event was also a popover container click event.
-      // We are comparing the click events because tracking the click element itself can
-      // be buggy if the content within the popover ever changes while its still open.
-      if (event !== this.eventClick) {
-        this._removePopover();
-      }
-      // We still want to allow purposeful closing of the popover from within,
-      // so this closes the popover if the click target has [data-popover-close]
-      // attribute, regardless of where it is in the dom.
-      // (This could be problematic in the future if we ever have the use case for
-      // multiple popovers open. This would close all of them at the same time.)
-      if (event.target.attributes['data-popover-close']) {
-        this._removePopover();
-      }
-    };
-
-    this._transitionEndHandler = () => {
-      if (this.get('isShowing') === false) {
-        run(() => this.set('isOpen', false));
-
-        this._popperElement.removeEventListener('transitionend', this._transitionEndHandler);
-
-        this._popperElement = null;
-
-        // remove body listener here instead of _removePopover, so we are sure
-        // the popover is actually closed first, otherwise a popover can be left
-        // open with no way to close
-        document.body.removeEventListener('click', this._handleBodyClick);
-      }
-    };
-
-    this._insertPopover = () => {
-      // Schedule these separately so that the element gets fully attached by setting
-      // `isOpen` to true, and only _then_ setting `isShowing` to true, triggering the
-      // CSS transition
-      run(() => this.set('isOpen', true));
-
-      this._insertFrame = requestAnimationFrame(() => {
-        run(() => this.set('isShowing', true));
-      });
-
-      this._popperElement = document.getElementById(this._popperId);
-
-      this._popperElement.addEventListener('transitionend', this._transitionEndHandler);
-
-      // We are storing the click event that happens directly on the popover container
-      // so that we can later compare it to the body click for closing logistics
-      this._popperElement.addEventListener('click', (event) => {
-        this.eventClick = event;
-      });
-
-      document.body.addEventListener('click', this._handleBodyClick);
-
-      // Add attribute used for tests, is not used in prod
-      if (DEBUG) {
-        this._popperElement.setAttribute('data-test-popover', '');
-      }
-    };
-
-    this._removePopover = () => {
-      run(() => this.set('isShowing', false));
-    };
-
-    this._target.addEventListener('click', this._clickHandler);
-  }
-
-  willDestroyElement() {
-    cancelAnimationFrame(this._insertFrame);
-    this._target.removeEventListener('click', this._clickHandler);
-    document.body.removeEventListener('click', this._handleBodyClick);
-  }
 }

--- a/addon/components/ice-popover.js
+++ b/addon/components/ice-popover.js
@@ -1,7 +1,7 @@
 import { argument, type } from 'ember-argument-decorators';
 import { unionOf } from 'ember-argument-decorators/types';
 
-import BasePopoverComponent from './utils/base-popover';
+import BasePopMenuComponent from './-private/base-pop-menu';
 
 import layout from '../templates/components/ice-popover';
 
@@ -49,7 +49,7 @@ import layout from '../templates/components/ice-popover';
  * </div>
  * ```
  */
-export default class IcePopoverComponent extends BasePopoverComponent {
+export default class IcePopoverComponent extends BasePopMenuComponent {
   layout = layout
 
   triggerEvent = 'click'

--- a/addon/components/ice-sub-dropdown.js
+++ b/addon/components/ice-sub-dropdown.js
@@ -1,12 +1,10 @@
-import Component from '@ember/component';
-
-import { tagName } from 'ember-decorators/component';
 import { argument, type } from 'ember-argument-decorators';
 
-import layout from '../templates/components/ice-sub-dropdown';
+import IceDropdownComponent from './ice-dropdown';
 
 /**
- * Subdropdown component that is used inside a dropdown menu item.
+ * Subdropdown component that is used inside a dropdown menu item. It targets
+ * its immediate parent element, and will open whenever that element is hovered.
  *
  * ```hbs
  * {{#ice-dropdown}}
@@ -26,22 +24,19 @@ import layout from '../templates/components/ice-sub-dropdown';
  * {{/ice-dropdown}}
  * ```
  */
-@tagName('')
-export default class IceSubDropdown extends Component {
-  layout = layout
+export default class IceSubDropdownComponent extends IceDropdownComponent {
+
+  triggerEvent = 'hover';
 
   // ----- Public Settings ------
 
   /**
-   * Used to determine the placement of the tooltip.
+   * Used to determine the placement of the sub-dropdown.
    * Should only use right-start, left-start, right-end, left-end.
    * Popper will auto move it if needed.
    */
   @argument
   @type('string')
-  placement = 'right-start'
+  placement = 'right-start';
 
-  @argument
-  @type('boolean')
-  renderInPlace = false;
 }

--- a/addon/components/ice-tooltip.js
+++ b/addon/components/ice-tooltip.js
@@ -1,18 +1,10 @@
-import { DEBUG } from '@glimmer/env';
-
-import Component from '@ember/component';
-import { run } from '@ember/runloop';
-import { guidFor } from '@ember/object/internals';
-
-import { argument, type, immutable } from 'ember-argument-decorators';
-import { unionOf } from 'ember-argument-decorators/types';
+import BasePopoverComponent from './utils/base-popover';
 
 import layout from '../templates/components/ice-tooltip';
 
 /**
- * Super simple tooltip component that uses popper.js. By default it targets its
- * parent element for placement and warps itself to the root of the DOM, but it
- * can also take a target selector as an option.
+ * Super simple tooltip component that uses popper.js. It targets its immediate
+ * parent element, and will open whenever that element is hovered.
  *
  * ```hbs
  * <div class="target">
@@ -35,141 +27,10 @@ import layout from '../templates/components/ice-tooltip';
  *     Tooltip with custom class
  *   {{/ice-tooltip}}
  * </div>
- *
- * <div data-tooltip-target>
- *   Target text
- * </div>
- * {{#ice-tooltip target="[data-tooltip-target]"}}
- *   Tooltip with external target, should be a unique id or attribute
- * {{/ice-tooltip}}
  * ```
  */
-export default class IceTooltip extends Component {
+export default class IceTooltipComponent extends BasePopoverComponent {
   layout = layout
 
-  // ----- Public Settings ------
-
-  /**
-   * Used to determine the placement of the tooltip;
-   * Can choose between auto, top, right, bottom, left;
-   * Can also add -start or -end modifier
-   */
-  @argument
-  @type('string')
-  placement = 'auto';
-
-  /**
-   * Selector or Element
-   */
-  @immutable
-  @argument
-  @type(unionOf(null, 'string', Element))
-  target = null;
-
-  // ----- Private Variables -----
-
-  /**
-   * Used to track if the tooltip is open and appended to the DOM
-   */
-  @type('boolean')
-  isOpen = false;
-
-  /**
-   * Used to track whether fade in/out animation should trigger
-   */
-  @type('boolean')
-  isShowing = false;
-
-  /**
-   * Used to store the popper element for adding/removing event listeners
-   */
-  _popperElement = null
-
-  /**
-   * Used to target/select the popper element after it's been inserted
-   */
-  _popperId = `${guidFor(this)}_popper`;
-
-  /**
-   * Used to as a proxy to pass along the class of this component to the actual popper
-   */
-  _popperClass = '';
-
-  constructor() {
-    super();
-
-    this._popperClass = this.class || '';
-    this._popperClass += ` ${this.classNames.join(' ')}`;
-
-    for (const binding of this.classNameBindings) {
-      if (binding.value) {
-        this._popperClass += ` ${binding.value()}`;
-      }
-    }
-  }
-
-  didInsertElement() {
-    this.element.className = '';
-
-    let target = this.get('target') || this.element.parentNode;
-
-    if (typeof target === 'string') {
-      const nodes = document.querySelectorAll(target);
-
-      // TODO: Add an assertion that throws if more than one node exists
-      target = nodes[0];
-    }
-
-    this._target = target;
-
-    this._mouseEnterHandler = () => {
-      // Schedule these separately so that the element gets fully attached by setting
-      // `isOpen` to true, and only _then_ setting `isShowing` to true, triggering the
-      // CSS transition
-      run(() => this.set('isOpen', true));
-
-      this._insertFrame = requestAnimationFrame(() => {
-        run(() => this.set('isShowing', true));
-      });
-
-      this._popperElement = document.getElementById(this._popperId);
-
-      // Adds the same mouseenter/mouseleave handlers as the target object. If
-      // the tooltip is entered before the transition has completed, `isVisible` will
-      // be reset to true and when `transitionend` fires it will do nothing.
-      this._popperElement.addEventListener('mouseenter', this._mouseEnterHandler);
-      this._popperElement.addEventListener('mouseleave', this._mouseLeaveHandler);
-      this._popperElement.addEventListener('transitionend', this._transitionEndHandler);
-
-      // Add attribute used for tests, is not used in prod
-      if (DEBUG) {
-        this._popperElement.setAttribute('data-test-tooltip', '');
-      }
-    };
-
-    this._mouseLeaveHandler = () => {
-      run(() => this.set('isShowing', false));
-    };
-
-    this._transitionEndHandler = () => {
-      if (this.get('isShowing') === false) {
-        run(() => this.set('isOpen', false));
-
-        this._popperElement.removeEventListener('mouseenter', this._mouseEnterHandler);
-        this._popperElement.removeEventListener('mouseleave', this._mouseLeaveHandler);
-        this._popperElement.removeEventListener('transitionend', this._transitionEndHandler);
-
-        this._popperElement = null;
-      }
-    };
-
-    this._target.addEventListener('mouseenter', this._mouseEnterHandler);
-    this._target.addEventListener('mouseleave', this._mouseLeaveHandler);
-  }
-
-  willDestroyElement() {
-    cancelAnimationFrame(this._insertFrame);
-    this._target.removeEventListener('mouseenter', this._mouseEnterHandler);
-    this._target.removeEventListener('mouseleave', this._mouseLeaveHandler);
-  }
+  triggerEvent = 'hover'
 }

--- a/addon/components/ice-tooltip.js
+++ b/addon/components/ice-tooltip.js
@@ -1,4 +1,4 @@
-import BasePopoverComponent from './utils/base-popover';
+import BasePopMenuComponent from './-private/base-pop-menu';
 
 import layout from '../templates/components/ice-tooltip';
 
@@ -29,7 +29,7 @@ import layout from '../templates/components/ice-tooltip';
  * </div>
  * ```
  */
-export default class IceTooltipComponent extends BasePopoverComponent {
+export default class IceTooltipComponent extends BasePopMenuComponent {
   layout = layout
 
   triggerEvent = 'hover'

--- a/addon/components/utils/base-popover.js
+++ b/addon/components/utils/base-popover.js
@@ -1,0 +1,219 @@
+import Component from '@ember/component';
+import { guidFor } from '@ember/object/internals';
+import { run } from '@ember/runloop';
+
+import { action } from 'ember-decorators/object';
+
+import { argument, type, immutable } from 'ember-argument-decorators';
+
+import { scheduler as raf } from 'ember-raf-scheduler';
+
+function closest(node, selector) {
+  let currentNode = node;
+
+  while (currentNode !== document.body && currentNode !== null) {
+    if (currentNode.matches(selector)) {
+      return currentNode;
+    }
+
+    currentNode = currentNode.parentNode;
+  }
+
+  return null;
+}
+
+/**
+ * Base class which ice-popover, ice-tooltip, and ice-dropdown all inherit from.
+ * Adds the event listeners and data attributes that are common to all of the popover-like
+ * components, and wraps all of their functionality.
+ */
+export default class BasePopoverComponent extends Component {
+  // ----- Arguments ------
+
+  /**
+   * Used to determine the placement of the popover
+   * Can choose between auto, top, right, bottom, left
+   * Can also add -start or -end modifier
+   */
+  @argument
+  @type('string')
+  placement = 'auto';
+
+  /**
+   * Determines whether or not the popover should render in place
+   */
+  @argument
+  @type('boolean')
+  renderInPlace = false;
+
+  /**
+   * The event that triggers the popover, can be `click` or `hover`,
+   * should be provided by the subclass
+   */
+  @immutable
+  @argument
+  @type('string')
+  triggerEvent = null;
+
+  // ----- Private Variables -----
+
+  /**
+   * Tracks if the tooltip is open
+   */
+  @type('boolean')
+  isOpen = false;
+
+  /**
+   * Stores the trigger element for adding/removing event listeners and data attributes
+   */
+  _triggerElement = null;
+
+  /**
+   * Stores the popper element for adding/removing event listeners and data attributes
+   */
+  _popperElement = null;
+
+  /**
+   * Used as proxy to pass along the class of this component to the actual popper
+   */
+  _popperClass = '';
+
+  constructor() {
+    super();
+
+    this._popperClass = `ice-base-popover ${this.class || ''} ${this.classNames.join(' ')}`;
+
+    for (const binding of this.classNameBindings) {
+      if (binding.value) {
+        this._popperClass += ` ${binding.value()}`;
+      }
+    }
+  }
+
+  didInsertElement() {
+    this._triggerElement = this.element.parentNode;
+    this._triggerElement.setAttribute('data-popover-trigger', guidFor(this));
+
+    if (this.get('triggerEvent') === 'click') {
+      this._triggerElement.addEventListener('mousedown', this._openPopoverHandler);
+    } else {
+      this._triggerElement.addEventListener('mouseenter', this._openPopoverHandler);
+      this._triggerElement.addEventListener('mouseleave', this._closePopoverHandler);
+    }
+  }
+
+  willDestroyElement() {
+    raf.forget(this._insertFrame);
+
+    if (this.get('triggerEvent') === 'click') {
+      this._triggerElement.removeEventListener('mousedown', this._openPopoverHandler);
+    } else {
+      this._triggerElement.removeEventListener('mouseenter', this._openPopoverHandler);
+      this._triggerElement.removeEventListener('mouseleave', this._closePopoverHandler);
+    }
+
+    this._triggerElement.removeAttribute('data-popover-trigger');
+
+    document.body.removeEventListener('mouseup', this._handleBodyClick);
+  }
+
+  /**
+   * Inserts the popover and sets up the body click listener
+   */
+  _insertPopover() {
+    // Schedule these separately so that the element gets fully attached by setting
+    // `isOpen` to true, and only _then_ setting `isShowing` to true, triggering the
+    // CSS transition
+    run(() => this.set('isOpen', true));
+
+    document.body.addEventListener('mouseup', this._handleBodyClick);
+  }
+
+  /**
+   * Removes the popover and tears down the body click listener
+   */
+  _removePopover() {
+    run(() => this.set('isOpen', false));
+
+    document.body.removeEventListener('mouseup', this._handleBodyClick);
+  }
+
+  /**
+   * Triggers when the popover has entered the DOM and the API has been established,
+   * allowing us to add data attributes and event handlers and mark the trigger as active
+   *
+   * @param {PopperAPI} api - The API received from the underlying popper
+   */
+  @action
+  popoverOpened({ popperElement }) {
+    this._popperElement = popperElement;
+    this._popperElement.setAttribute('data-popover-content', guidFor(this));
+    this._triggerElement.classList.add('is-active');
+
+    if (this.get('triggerEvent') === 'hover') {
+      this._popperElement.addEventListener('mouseenter', this._openPopoverHandler);
+      this._popperElement.addEventListener('mouseleave', this._closePopoverHandler);
+    }
+  }
+
+  /**
+   * Triggers when the popover has been fully removed from the DOM (e.g. after animations)
+   * allowing us to teardown event handlers and mark the trigger element as inactive
+   */
+  @action
+  popoverClosed() {
+    if (this.get('triggerEvent') === 'hover') {
+      this._popperElement.removeEventListener('mouseenter', this._openPopoverHandler);
+      this._popperElement.removeEventListener('mouseleave', this._closePopoverHandler);
+    }
+
+    this._triggerElement.classList.remove('is-active');
+    this._popperElement.removeAttribute('data-popover-content');
+    this._popperElement = null;
+  }
+
+  // ----- Event Handlers -----
+
+  /**
+   * Opens the popover
+   */
+  _openPopoverHandler = () => {
+    if (!this.get('isOpen')) {
+      this._isOpening = true;
+      this._insertPopover();
+    }
+  }
+
+  /**
+   * Closes the popover
+   */
+  _closePopoverHandler = () => {
+    if (this.get('isOpen')) {
+      this._isOpening = false;
+      this._removePopover();
+    }
+  }
+
+  /**
+   * Handles a click on the body in general when a popover is open. If the clicked element is not
+   * a child of the popover, or is marked with `data-close`, closes the popover.
+   */
+  _handleBodyClick = ({ target }) => {
+    if (this._isOpening) {
+      this._isOpening = false;
+    } else if (closest(target, '.ice-base-popover') === null) {
+      // We do not want _removePopover to trigger when clicking inside of the popover.
+      // Here we check whether the body click event was also a popover container click event.
+      // We are comparing the click events because tracking the click element itself can
+      // be buggy if the content within the popover ever changes while its still open.
+
+      this._removePopover();
+
+    } else if (closest(target, '[data-close]:not([disabled])')) {
+      // We still want to allow purposeful closing of the popover from within,
+      // so this closes the popover if the click target has [data-popover-close] attribute
+
+      this._removePopover();
+    }
+  }
+}

--- a/addon/templates/components/animated-popper.hbs
+++ b/addon/templates/components/animated-popper.hbs
@@ -1,0 +1,13 @@
+{{unbound _parentFinder}}
+
+{{#if renderInDOM}}
+  {{#ember-popper
+    target=_target
+    placement=placement
+    renderInPlace=renderInPlace
+    registerAPI="registerAPI"
+    class=(concat "ice-animated " (if makeVisible "is-visible " "") popperClass)
+  }}
+    {{yield}}
+  {{/ember-popper}}
+{{/if}}

--- a/addon/templates/components/ice-dropdown.hbs
+++ b/addon/templates/components/ice-dropdown.hbs
@@ -1,14 +1,12 @@
-{{#if isOpen}}
-  {{#ember-popper
-    id=_popperId
-    target=_target
-    placement=placement
-    renderInPlace=renderInPlace
-    class="ice-dropdown"
-    classNameBindings="isShowing:is-visible _popperClass"
-  }}
-    <div class="ice-dropdown-content">
-      {{yield}}
-    </div>
-  {{/ember-popper}}
-{{/if}}
+{{#animated-popper
+  isOpen=isOpen
+  placement=placement
+  renderInPlace=renderInPlace
+  popperClass=(concat "ice-dropdown " _popperClass)
+  onOpen="popoverOpened"
+  onClose="popoverClosed"
+}}
+  <div class="ice-dropdown-content">
+    {{yield}}
+  </div>
+{{/animated-popper}}

--- a/addon/templates/components/ice-popover.hbs
+++ b/addon/templates/components/ice-popover.hbs
@@ -1,17 +1,16 @@
-{{#if isOpen}}
-  {{#ember-popper
-    id=_popperId
-    target=_target
-    placement=placement
-    class="ice-popover"
-    classNameBindings="isShowing:is-visible popoverTitle:has-title _popperClass"
-  }}
-    <div class="ice-popover-content">
-      {{#if popoverTitle}}
-        <header class="ice-popover-title" data-test-popover-header>{{popoverTitle}}</header>
-      {{/if}}
-      {{yield}}
-    </div>
-    <div class="popper-arrow" x-arrow></div>
-  {{/ember-popper}}
-{{/if}}
+{{#animated-popper
+  isOpen=isOpen
+  placement=placement
+  renderInPlace=renderInPlace
+  popperClass=(concat "ice-popover " (if popoverTitle "has-title ") _popperClass)
+  onOpen="popoverOpened"
+  onClose="popoverClosed"
+}}
+  <div class="ice-popover-content">
+    {{#if popoverTitle}}
+      <header class="ice-popover-title" data-test-popover-header>{{popoverTitle}}</header>
+    {{/if}}
+    {{yield}}
+  </div>
+  <div class="popper-arrow" x-arrow></div>
+{{/animated-popper}}

--- a/addon/templates/components/ice-sub-dropdown.hbs
+++ b/addon/templates/components/ice-sub-dropdown.hbs
@@ -1,8 +1,0 @@
-{{#ice-dropdown
-  class="ice-sub-dropdown"
-  placement=placement
-  renderInPlace=renderInPlace
-  isTriggeredOnHover=true
-}}
-  {{yield}}
-{{/ice-dropdown}}

--- a/addon/templates/components/ice-tooltip-icon.hbs
+++ b/addon/templates/components/ice-tooltip-icon.hbs
@@ -1,3 +1,3 @@
-{{#ice-tooltip placement=placement class=tooltipClass}}
+{{#ice-tooltip data-test-icon-tooltip=true placement=placement class=tooltipClass}}
   {{yield}}
 {{/ice-tooltip}}

--- a/addon/templates/components/ice-tooltip.hbs
+++ b/addon/templates/components/ice-tooltip.hbs
@@ -1,15 +1,13 @@
-{{#if isOpen}}
-  {{#ember-popper
-    id=_popperId
-    target=_target
-    placement=placement
-    renderInPlace=renderInPlace
-    class="ice-tooltip"
-    classNameBindings="isShowing:is-visible _popperClass"
-  }}
-    <div class="ice-tooltip-content">
-      {{yield}}
-    </div>
-    <div class="popper-arrow" x-arrow></div>
-  {{/ember-popper}}
-{{/if}}
+{{#animated-popper
+  isOpen=isOpen
+  placement=placement
+  renderInPlace=renderInPlace
+  popperClass=(concat "ice-tooltip " _popperClass)
+  onOpen="popoverOpened"
+  onClose="popoverClosed"
+}}
+  <div class="ice-tooltip-content">
+    {{yield}}
+  </div>
+  <div class="popper-arrow" x-arrow></div>
+{{/animated-popper}}

--- a/app/components/animated-popper.js
+++ b/app/components/animated-popper.js
@@ -1,0 +1,1 @@
+export { default } from '@addepar/ice-pop/components/animated-popper';

--- a/app/components/animated-popper.js
+++ b/app/components/animated-popper.js
@@ -1,1 +1,1 @@
-export { default } from '@addepar/ice-pop/components/animated-popper';
+export { default } from '@addepar/ice-pop/components/-private/animated-popper';

--- a/package.json
+++ b/package.json
@@ -17,13 +17,15 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "@addepar/ice-box": "^0.1.0",
+    "@addepar/ice-box": "^0.1.1",
     "ember-argument-decorators": "~0.6.1",
     "ember-cli-babel": "^6.3.0",
     "ember-cli-htmlbars": "^2.0.1",
     "ember-decorators": "^1.3.1",
-    "ember-legacy-class-transform": "~0.1.2",
-    "ember-popper": "~0.6.6"
+    "ember-legacy-class-transform": "~0.1.3",
+    "ember-classy-page-object": "^0.1.0",
+    "ember-popper": "^0.7.1",
+    "ember-raf-scheduler": "^0.1.0"
   },
   "devDependencies": {
     "@addepar/eslint-config": "^1.0.0",
@@ -36,6 +38,7 @@
     "ember-cli-eslint": "^3.0.0",
     "ember-cli-htmlbars-inline-precompile": "^0.4.3",
     "ember-cli-inject-live-reload": "^1.4.1",
+    "ember-cli-page-object": "pzuraq/ember-cli-page-object#af35424",
     "ember-cli-qunit": "^4.0.0",
     "ember-cli-sass": "^6.1.3",
     "ember-cli-sass-lint": "^1.0.4",
@@ -50,7 +53,7 @@
     "ember-native-dom-helpers": "^0.5.0",
     "ember-resolver": "^4.0.0",
     "ember-source": "~2.14.0",
-    "ember-test-selectors": "pzuraq/ember-test-selectors#24334cd9a0de17a4201c5354f8b4cd9ea774c208",
+    "ember-test-selectors": "simplabs/ember-test-selectors#251be25",
     "loader.js": "^4.2.3"
   },
   "engines": {

--- a/tests/dummy/app/templates/dropdown.hbs
+++ b/tests/dummy/app/templates/dropdown.hbs
@@ -329,49 +329,24 @@
         <ul class="ice-dropdown-menu">
           <li><a>Foo bar baz</a></li>
           <li><a>Lorem ipsum</a></li>
-          <li><a>I'm Mr. Meseeks</a> <div class="ice-dropdown-caret"></div>
-          {{#ice-sub-dropdown}}
-            <ul class="ice-dropdown-menu">
-              <li><a>Foo bar baz</a></li>
-              <li><a>Lorem ipsum</a></li>
-              <li><a>I'm Mr. Meseeks</a></li>
-              <li class="list-divider"></li>
-              <li><a>Foo bar baz</a></li>
-              <li><a disabled>Lorem ipsum</a></li>
-              <li><a>I'm Mr. Meseeks</a></li>
-            </ul>
-          {{/ice-sub-dropdown}}
+          <li>
+            <a>I'm Mr. Meseeks</a>
+            <div class="ice-dropdown-caret"></div>
+            {{#ice-sub-dropdown}}
+              <ul class="ice-dropdown-menu">
+                <li><a>Foo bar baz</a></li>
+                <li><a>Lorem ipsum</a></li>
+                <li><a>I'm Mr. Meseeks</a></li>
+                <li class="list-divider"></li>
+                <li><a>Foo bar baz</a></li>
+                <li><a disabled>Lorem ipsum</a></li>
+                <li><a>I'm Mr. Meseeks</a></li>
+              </ul>
+            {{/ice-sub-dropdown}}
           </li>
           <li><a>Foo bar baz</a></li>
           <li><a>Lorem ipsum</a></li>
           <li><a>I'm Mr. Meseeks</a></li>
-        </ul>
-      {{/ice-dropdown}}
-    </button>
-  </div>
-  <div class="demo-item">
-    <button class="button-text popover-target">
-      Custom links <div class="ice-dropdown-caret"></div>
-      {{#ice-dropdown closeItems=false}}
-        <ul class="ice-dropdown-menu">
-          <li><a data-dropdown-close>Foo bar baz</a></li>
-          <li><a data-dropdown-close>Lorem ipsum</a></li>
-          <li><a>I'm Mr. Meseeks</a> <div class="ice-dropdown-caret"></div>
-          {{#ice-sub-dropdown}}
-            <ul class="ice-dropdown-menu">
-              <li><a data-dropdown-close>Foo bar baz</a></li>
-              <li><a data-dropdown-close>Lorem ipsum</a></li>
-              <li><a data-dropdown-close>I'm Mr. Meseeks</a></li>
-              <li class="list-divider"></li>
-              <li><a data-dropdown-close>Foo bar baz</a></li>
-              <li><a data-dropdown-close>Lorem ipsum</a></li>
-              <li><a data-dropdown-close>I'm Mr. Meseeks</a></li>
-            </ul>
-          {{/ice-sub-dropdown}}
-          </li>
-          <li><a data-dropdown-close>Foo bar baz</a></li>
-          <li><a data-dropdown-close>Lorem ipsum</a></li>
-          <li><a data-dropdown-close>I'm Mr. Meseeks</a></li>
         </ul>
       {{/ice-dropdown}}
     </button>

--- a/tests/index.html
+++ b/tests/index.html
@@ -18,6 +18,10 @@
       #ember-testing-container {
         position: fixed !important;
       }
+
+      .ice-animated {
+        transition-duration: 0s !important;
+      }
     </style>
 
     {{content-for "head-footer"}}

--- a/tests/integration/components/ice-dropdown-test.js
+++ b/tests/integration/components/ice-dropdown-test.js
@@ -1,277 +1,189 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { find, click } from 'ember-native-dom-helpers';
 
-import waitForAnimations from '../../helpers/wait-for-animations';
-import dropdownHelpers from '../../helpers/components/dropdown-helpers';
+import { PageObject } from 'ember-classy-page-object';
+import { clickable, hasClass } from 'ember-cli-page-object';
 
-moduleForComponent('ice-dropdown', 'Integration | Component | ice dropdown', {
+import IceDropdownPage from '@addepar/ice-pop/test-support/pages/ice-dropdown';
+
+const DropdownHelper = IceDropdownPage.extend({ scope: '[data-test-dropdown]' });
+
+moduleForComponent('ice-dropdown', 'Integration | Component | ice-dropdown', {
   integration: true
 });
 
-test('dropdown box renders when parent element is the target', async function(assert) {
-  assert.expect(3);
+test('dropdown works', async function(assert) {
+  assert.expect(4);
 
   this.render(hbs`
-    <div data-test-dropdown-target>
+    <div>
       Target
-      {{#ice-dropdown}}
+      {{#ice-dropdown data-test-dropdown=true}}
         template block text
       {{/ice-dropdown}}
     </div>
   `);
 
-  assert.equal(dropdownHelpers.getDropdownsCount(), 0,
-    'dropdown not rendered initially');
+  const dropdown = DropdownHelper.create();
 
-  await dropdownHelpers.toggleDropdown('[data-test-dropdown-target]');
+  assert.ok(!dropdown.isOpen, 'dropdown not rendered initially');
 
-  await waitForAnimations(dropdownHelpers.DROPDOWN_SELECTOR);
+  await dropdown.open();
 
-  assert.equal(dropdownHelpers.getDropdownsCount(), 1,
-    'only one dropdown is rendered');
+  assert.ok(dropdown.isOpen, 'dropdown is rendered');
+  assert.equal(dropdown.content.text, 'template block text', 'dropdown has correct text');
 
-  await dropdownHelpers.toggleDropdown('[data-test-dropdown-target]');
-  await waitForAnimations(dropdownHelpers.DROPDOWN_SELECTOR);
+  await dropdown.close();
 
-  assert.equal(dropdownHelpers.getDropdownsCount(), 0,
-    'dropdown removed after clicking the target again');
-});
-
-test('dropdown box renders when another element is the target', async function(assert) {
-  assert.expect(3);
-
-  this.render(hbs`
-    <div data-test-dropdown-target>
-      Target
-    </div>
-
-    {{#ice-dropdown target="[data-test-dropdown-target]"}}
-      template block text
-    {{/ice-dropdown}}
-  `);
-
-  assert.equal(dropdownHelpers.getDropdownsCount(), 0,
-    'dropdown not rendered initially');
-
-  await dropdownHelpers.toggleDropdown('[data-test-dropdown-target]');
-  await waitForAnimations(dropdownHelpers.DROPDOWN_SELECTOR);
-
-  assert.equal(dropdownHelpers.getDropdownsCount(), 1,
-    'only one dropdown is rendered');
-
-  await dropdownHelpers.toggleDropdown('[data-test-dropdown-target]');
-  await waitForAnimations(dropdownHelpers.DROPDOWN_SELECTOR);
-
-  assert.equal(dropdownHelpers.getDropdownsCount(), 0,
-    'dropdown removed after clicking the target again');
+  assert.ok(!dropdown.isOpen, 'dropdown removed after exiting the parent');
 });
 
 test('dropdown box closes when element outside of dropdown is clicked', async function(assert) {
   assert.expect(2);
 
   this.render(hbs`
-    <div data-test-outside-element></div>
-    <div data-test-dropdown-target>
-      Target
-      {{#ice-dropdown}}
-        template block text
-      {{/ice-dropdown}}
+    <div data-test-content>
+      <div data-test-outside-element></div>
+      <div>
+        Target
+        {{#ice-dropdown data-test-dropdown=true}}
+          template block text
+        {{/ice-dropdown}}
+      </div>
     </div>
   `);
 
-  await dropdownHelpers.toggleDropdown('[data-test-dropdown-target]');
-  await waitForAnimations(dropdownHelpers.DROPDOWN_SELECTOR);
+  const content = new PageObject({
+    scope: '[data-test-content]',
+    clickOutsideElement: clickable('[data-test-outside-element]'),
 
-  assert.equal(dropdownHelpers.getDropdownsCount(), 1,
-    'dropdown is rendered');
+    dropdown: DropdownHelper
+  }).create();
 
-  await click('[data-test-outside-element]');
-  await waitForAnimations(dropdownHelpers.DROPDOWN_SELECTOR);
+  await content.dropdown.open();
 
-  assert.equal(dropdownHelpers.getDropdownsCount(), 0,
-    'dropdown removed after clicking the outside element');
+  assert.ok(content.dropdown.isOpen, 'dropdown is rendered');
+
+  await content.clickOutsideElement();
+
+  assert.ok(!content.dropdown.isOpen, 'dropdown closed when outside element clicked');
 });
 
 test('clicking inside dropdown only closes for certain elements', async function(assert) {
   assert.expect(6);
 
   this.render(hbs`
-    <div data-test-dropdown-target>
+    <div>
       Target
-      {{#ice-dropdown}}
+      {{#ice-dropdown data-test-dropdown=true}}
         <ul class="ice-dropdown-menu">
           <li class="list-group-header" data-test-menu-header>Group Header</li>
-          <li><a disabled>Lorem ipsum</a></li>
+          <li><a data-close disabled>Lorem ipsum</a></li>
           <li class="list-divider" data-test-list-divider></li>
-          <li data-dropdown-close>Foo bar baz</li>
-
+          <li data-test-close-item data-close>Foo bar baz</li>
         </ul>
       {{/ice-dropdown}}
     </div>
   `);
 
-  await dropdownHelpers.toggleDropdown('[data-test-dropdown-target]');
-  await waitForAnimations(dropdownHelpers.DROPDOWN_SELECTOR);
+  const dropdown = DropdownHelper.extend({
+    content: {
+      click: clickable(),
+      clickMenuHeader: clickable('[data-test-menu-header]'),
+      clickDisabledItem: clickable('[disabled]'),
+      clickDivider: clickable('[data-test-list-divider]'),
+      clickCloseItem: clickable('[data-test-close-item]')
+    }
+  }).create();
 
-  assert.equal(dropdownHelpers.getDropdownsCount(), 1,
-    'dropdown is rendered');
+  await dropdown.open();
 
-  await click(dropdownHelpers.DROPDOWN_SELECTOR);
+  assert.ok(dropdown.isOpen, 'dropdown is rendered');
 
-  assert.equal(dropdownHelpers.getDropdownsCount(), 1,
-    'dropdown does not close after clicking the dropdown container');
+  await dropdown.content.click();
 
-  await click('[data-test-menu-header]');
+  assert.ok(dropdown.isOpen, 'dropdown does not close after clicking the dropdown container');
 
-  assert.equal(dropdownHelpers.getDropdownsCount(), 1,
-    'dropdown does not close after clicking a menu header');
+  await dropdown.content.clickMenuHeader();
 
-  await click('[disabled]');
+  assert.ok(dropdown.isOpen, 'dropdown does not close after clicking a menu header');
 
-  assert.equal(dropdownHelpers.getDropdownsCount(), 1,
-    'dropdown does not close after clicking a disabled item');
+  await dropdown.content.clickDisabledItem();
 
-  await click('[data-test-list-divider]');
+  assert.ok(dropdown.isOpen, 'dropdown does not close after clicking a disabled item');
 
-  assert.equal(dropdownHelpers.getDropdownsCount(), 1,
-    'dropdown does not close after clicking a list divider');
+  await dropdown.content.clickDivider();
 
-  await dropdownHelpers.clickDropdownCloseElement();
-  await waitForAnimations(dropdownHelpers.DROPDOWN_SELECTOR);
+  assert.ok(dropdown.isOpen, 'dropdown does not close after clicking a list divider');
 
-  assert.equal(dropdownHelpers.getDropdownsCount(), 0,
-    'dropdown removed after clicking the close element');
-});
+  await dropdown.content.clickCloseItem();
 
-test('List item links automatically become closable elements', async function(assert) {
-  assert.expect(1);
-
-  this.render(hbs`
-    <div data-test-dropdown-target>
-      Target
-      {{#ice-dropdown}}
-        <ul class="ice-dropdown-menu">
-          <li><a data-test-link>Foo bar baz</a></li>
-        </ul>
-      {{/ice-dropdown}}
-    </div>
-  `);
-
-  await dropdownHelpers.toggleDropdown('[data-test-dropdown-target]');
-  await waitForAnimations(dropdownHelpers.DROPDOWN_SELECTOR);
-
-  // a single attribute's value is blank by default
-  assert.equal(dropdownHelpers.getCloseAttribute('[data-test-link]'), '',
-    'Link has correct close attribute');
-});
-
-test('Can turn off auto closing menu items', async function(assert) {
-  assert.expect(1);
-
-  this.render(hbs`
-    <div data-test-dropdown-target>
-      Target
-      {{#ice-dropdown closeItems=false}}
-        <ul class="ice-dropdown-menu">
-          <li><a data-test-link>Foo bar baz</a></li>
-        </ul>
-      {{/ice-dropdown}}
-    </div>
-  `);
-
-  await dropdownHelpers.toggleDropdown('[data-test-dropdown-target]');
-  await waitForAnimations(dropdownHelpers.DROPDOWN_SELECTOR);
-
-  assert.equal(dropdownHelpers.getCloseAttribute('[data-test-link]'), null,
-    'Link does not have close attribute');
+  assert.ok(!dropdown.isOpen, 'dropdown removed after clicking the close element');
 });
 
 test('dropdown box modifier class can be added', async function(assert) {
   assert.expect(1);
 
   this.render(hbs`
-    <div data-test-dropdown-target>
+    <div>
       Target
-      {{#ice-dropdown class="foobar"}}
+      {{#ice-dropdown data-test-dropdown=true class="foobar"}}
         template block text
       {{/ice-dropdown}}
     </div>
   `);
 
-  await dropdownHelpers.toggleDropdown('[data-test-dropdown-target]');
-  await waitForAnimations(dropdownHelpers.DROPDOWN_SELECTOR);
+  const dropdown = DropdownHelper.extend({
+    content: {
+      hasAdditionalClass: hasClass('foobar')
+    }
+  }).create();
 
-  assert.equal(dropdownHelpers.getDropdown().classList.contains('foobar'), true,
-    'dropdown box reflects additional class');
-});
+  await dropdown.open();
 
-test('dropdown box correctly renders content', async function(assert) {
-  assert.expect(1);
-
-  this.render(hbs`
-    <div data-test-dropdown-target>
-      Target
-      {{#ice-dropdown}}
-        template block text
-      {{/ice-dropdown}}
-    </div>
-  `);
-
-  await dropdownHelpers.toggleDropdown('[data-test-dropdown-target]');
-  await waitForAnimations(dropdownHelpers.DROPDOWN_SELECTOR);
-
-  assert.equal(dropdownHelpers.getDropdown().textContent.trim(), 'template block text',
-    'dropdown renders given content');
+  assert.ok(dropdown.content.hasAdditionalClass, 'dropdown box reflects additional class');
 });
 
 test('dropdown box direction can be modified', async function(assert) {
-  assert.expect(2);
+  assert.expect(1);
 
   this.render(hbs`
-    <div data-test-dropdown-target>
+    <div>
       Target
-      {{#ice-dropdown placement="bottom-end"}}
+      {{#ice-dropdown data-test-dropdown=true placement="bottom-end"}}
         template block text
       {{/ice-dropdown}}
     </div>
   `);
 
-  await dropdownHelpers.toggleDropdown('[data-test-dropdown-target]');
-  await waitForAnimations(dropdownHelpers.DROPDOWN_SELECTOR);
+  const dropdown = DropdownHelper.create();
 
-  assert.equal(dropdownHelpers.getDropdown().getAttribute('x-placement'), 'bottom-end',
-    'dropdown box reflects correct direction');
-  assert.equal(find('[data-test-dropdown-target]').getAttribute('dropdown-placement'), 'bottom-end',
-    'dropdown target reflects correct dropdown placement');
+  await dropdown.open();
+
+  assert.equal(dropdown.content.placement, 'bottom-end', 'dropdown box reflects correct direction');
 });
 
-test('sub dropdown button is active when open', async function(assert) {
-  assert.expect(2);
+test('dropdown trigger element is marked as active when open', async function(assert) {
+  assert.expect(3);
 
   this.render(hbs`
-    <div data-test-dropdown-target>
+    <div>
       Target
-      {{#ice-dropdown}}
-        <ul class="ice-dropdown-menu">
-          <li data-test-sub-item><a>Foo bar baz</a>
-          {{#ice-sub-dropdown}}
-            <ul class="ice-dropdown-menu">
-              <li><a>Foo bar baz</a></li>
-            </ul>
-          {{/ice-sub-dropdown}}
-          </li>
-        </ul>
+      {{#ice-dropdown data-test-dropdown=true placement="bottom-end"}}
+        template block text
       {{/ice-dropdown}}
     </div>
   `);
 
-  assert.equal(find('[data-test-dropdown-target]').classList.contains('is-active'), false,
-    'Dropdown target does not initially reflect active class');
+  const dropdown = DropdownHelper.create();
 
-  await dropdownHelpers.toggleDropdown('[data-test-dropdown-target]');
-  await waitForAnimations(dropdownHelpers.DROPDOWN_SELECTOR);
+  assert.ok(!dropdown.trigger.isActive, 'dropdown trigger is not marked as active when the dropdown is closed');
 
-  assert.equal(find('[data-test-dropdown-target]').classList.contains('is-active'), true,
-    'Dropdown target reflects active class');
+  await dropdown.open();
+
+  assert.ok(dropdown.trigger.isActive, 'dropdown trigger is marked as active when the dropdown is open');
+
+  await dropdown.close();
+
+  assert.ok(!dropdown.trigger.isActive, 'dropdown trigger is not marked as active when the dropdown is closed again');
 });

--- a/tests/integration/components/ice-tooltip-icon-test.js
+++ b/tests/integration/components/ice-tooltip-icon-test.js
@@ -1,12 +1,13 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
-import waitForAnimations from '../../helpers/wait-for-animations';
-import tooltipHelpers from '../../helpers/components/tooltip-helpers';
+import { hasClass } from 'ember-cli-page-object';
 
-import { find } from 'ember-native-dom-helpers';
+import IceTooltipIconPage from '@addepar/ice-pop/test-support/pages/ice-tooltip-icon';
 
-moduleForComponent('ice-tooltip-icon', 'Integration | Component | ice tooltip icon', {
+const IconHelper = IceTooltipIconPage.extend({ scope: '[data-test-tooltip-icon]' });
+
+moduleForComponent('ice-tooltip-icon', 'Integration | Component | ice-tooltip-icon', {
   integration: true
 });
 
@@ -19,11 +20,10 @@ test('target icon renders', async function(assert) {
     {{/ice-tooltip-icon}}
   `);
 
-  const tooltip = find('[data-test-tooltip-icon]');
+  const icon = IconHelper.create();
 
-  assert.ok(tooltip, 'a tooltip icon target is rendered');
-  assert.equal(tooltip.classList.contains('fa-question-circle'), true,
-    'tooltip has correct default class');
+  assert.ok(icon.isPresent, 'a tooltip icon target is rendered');
+  assert.ok(icon.isIcon('fa-question-circle'), 'tooltip has correct default class');
 });
 
 test('tooltip works as expected', async function(assert) {
@@ -35,19 +35,16 @@ test('tooltip works as expected', async function(assert) {
     {{/ice-tooltip-icon}}
   `);
 
-  await tooltipHelpers.openTooltip('[data-test-tooltip-icon]');
-  await waitForAnimations(tooltipHelpers.TOOLTIP_SELECTOR);
+  const icon = IconHelper.create();
 
-  assert.equal(tooltipHelpers.getTooltipsCount(), 1,
-    'hovering icon target renders a tooltip');
-  assert.equal(tooltipHelpers.getTooltip().textContent.trim(), 'template block text',
-    'tooltip content renders');
+  await icon.tooltip.open();
 
-  await tooltipHelpers.closeTooltip('[data-test-tooltip-icon]');
-  await waitForAnimations(tooltipHelpers.TOOLTIP_SELECTOR);
+  assert.ok(icon.tooltip.content.isPresent, 'hovering icon target renders a tooltip');
+  assert.equal(icon.tooltip.content.text, 'template block text', 'tooltip content renders');
 
-  assert.equal(tooltipHelpers.getTooltipsCount(), 0,
-    'tooltip removed after exiting the tooltip icon');
+  await icon.tooltip.close();
+
+  assert.ok(!icon.tooltip.content.isPresent, 'tooltip removed after exiting the tooltip icon');
 });
 
 test('tooltip icon class can be modified', async function(assert) {
@@ -59,10 +56,10 @@ test('tooltip icon class can be modified', async function(assert) {
     {{/ice-tooltip-icon}}
   `);
 
-  assert.equal(find('[data-test-tooltip-icon]').classList.contains('fa-exclamation'), true,
-    'tooltip icon has new class');
-  assert.equal(find('[data-test-tooltip-icon]').classList.contains('fa-question-circle'), false,
-    'tooltip icon no longer has default class');
+  const icon = IconHelper.create();
+
+  assert.ok(icon.isIcon('fa-exclamation'), 'tooltip icon has new class');
+  assert.ok(!icon.isIcon('fa-question-circle'), 'tooltip icon no longer has default class');
 });
 
 test('tooltip box modifier class can be added', async function(assert) {
@@ -74,11 +71,17 @@ test('tooltip box modifier class can be added', async function(assert) {
     {{/ice-tooltip-icon}}
   `);
 
-  await tooltipHelpers.openTooltip('[data-test-tooltip-icon]');
-  await waitForAnimations(tooltipHelpers.TOOLTIP_SELECTOR);
+  const icon = IconHelper.extend({
+    tooltip: {
+      content: {
+        isErrored: hasClass('error-tooltip')
+      }
+    }
+  }).create();
 
-  assert.equal(tooltipHelpers.getTooltip().classList.contains('error-tooltip'), true,
-    'tooltip box reflects additional class');
+  await icon.tooltip.open();
+
+  assert.ok(icon.tooltip.content.isErrored, 'tooltip box reflects additional class');
 });
 
 test('tooltip box direction can be modified', async function(assert) {
@@ -90,9 +93,9 @@ test('tooltip box direction can be modified', async function(assert) {
     {{/ice-tooltip-icon}}
   `);
 
-  await tooltipHelpers.openTooltip('[data-test-tooltip-icon]');
-  await waitForAnimations(tooltipHelpers.TOOLTIP_SELECTOR);
+  const icon = IconHelper.create();
 
-  assert.equal(tooltipHelpers.getTooltip().getAttribute('x-placement'), 'bottom-end',
-    'tooltip box reflects correct direction');
+  await icon.tooltip.open();
+
+  assert.equal(icon.tooltip.content.placement, 'bottom-end', 'tooltip box reflects correct direction');
 });

--- a/tests/integration/components/ice-tooltip-test.js
+++ b/tests/integration/components/ice-tooltip-test.js
@@ -1,155 +1,139 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+
 import { triggerEvent } from 'ember-native-dom-helpers';
 
-import waitForAnimations from '../../helpers/wait-for-animations';
-import tooltipHelpers from '../../helpers/components/tooltip-helpers';
+import IceTooltipPage from '@addepar/ice-pop/test-support/pages/ice-tooltip';
 
-moduleForComponent('ice-tooltip', 'Integration | Component | ice tooltip', {
+import { hasClass } from 'ember-cli-page-object';
+
+const TooltipHelper = IceTooltipPage.extend({ scope: '[data-test-tooltip]' });
+
+moduleForComponent('ice-tooltip', 'Integration | Component | ice-tooltip', {
   integration: true
 });
 
-test('tooltip box renders when parent element is the target', async function(assert) {
-  assert.expect(3);
+test('tooltip works', async function(assert) {
+  assert.expect(4);
 
   this.render(hbs`
-    <div data-test-tooltip-target>
+    <div>
       Target
-      {{#ice-tooltip}}
+      {{#ice-tooltip data-test-tooltip=true}}
         template block text
       {{/ice-tooltip}}
     </div>
   `);
 
-  assert.equal(tooltipHelpers.getTooltipsCount(), 0,
-    'tooltip not rendered initially');
+  const tooltip = TooltipHelper.create();
 
-  await tooltipHelpers.openTooltip('[data-test-tooltip-target]');
-  await waitForAnimations(tooltipHelpers.TOOLTIP_SELECTOR);
+  assert.ok(!tooltip.isOpen, 'tooltip not rendered initially');
 
-  assert.equal(tooltipHelpers.getTooltipsCount(), 1,
-    'only one tooltip is rendered');
+  await tooltip.open();
 
-  await tooltipHelpers.closeTooltip('[data-test-tooltip-target]');
-  await waitForAnimations(tooltipHelpers.TOOLTIP_SELECTOR);
+  assert.ok(tooltip.isOpen, 'tooltip is rendered');
+  assert.equal(tooltip.content.text, 'template block text', 'tooltip has correct text');
 
-  assert.equal(tooltipHelpers.getTooltipsCount(), 0,
-    'tooltip removed after exiting the parent');
-});
+  await tooltip.close();
 
-test('tooltip box renders when another element is the target', async function(assert) {
-  assert.expect(3);
-
-  this.render(hbs`
-    <div data-test-tooltip-target>
-      Target
-    </div>
-
-    {{#ice-tooltip target="[data-test-tooltip-target]"}}
-      template block text
-    {{/ice-tooltip}}
-  `);
-
-  assert.equal(tooltipHelpers.getTooltipsCount(), 0,
-    'tooltip not rendered initially');
-
-  await tooltipHelpers.openTooltip('[data-test-tooltip-target]');
-  await waitForAnimations(tooltipHelpers.TOOLTIP_SELECTOR);
-
-  assert.equal(tooltipHelpers.getTooltipsCount(), 1,
-    'only one tooltip is rendered');
-
-  await tooltipHelpers.closeTooltip('[data-test-tooltip-target]');
-  await waitForAnimations(tooltipHelpers.TOOLTIP_SELECTOR);
-
-  assert.equal(tooltipHelpers.getTooltipsCount(), 0,
-    'tooltip removed after exiting the parent');
+  assert.ok(!tooltip.isOpen, 'tooltip removed after exiting the parent');
 });
 
 test('tooltip remains rendered when tooltip box itself is hovered', async function(assert) {
-  assert.expect(3);
+  assert.expect(4);
 
   this.render(hbs`
-    <div data-test-tooltip-target>
+    <div>
       Target
-      {{#ice-tooltip}}
+      {{#ice-tooltip data-test-tooltip=true}}
         template block text
       {{/ice-tooltip}}
     </div>
   `);
 
-  await tooltipHelpers.openTooltip('[data-test-tooltip-target]');
+  const tooltip = TooltipHelper.create();
 
-  assert.equal(tooltipHelpers.getTooltipsCount(), 1,
-    'tooltip rendered after entering the target');
+  assert.ok(!tooltip.isOpen, 'tooltip not rendered initially');
 
-  triggerEvent('[data-test-tooltip-target]', 'mouseleave');
-  await triggerEvent(tooltipHelpers.TOOLTIP_SELECTOR, 'mouseenter');
-  await waitForAnimations(tooltipHelpers.TOOLTIP_SELECTOR);
+  await tooltip.open();
 
-  assert.equal(tooltipHelpers.getTooltipsCount(), 1,
-    'tooltip is still rendered after entering the tooltip box');
+  assert.ok(tooltip.isOpen, 'tooltip is rendered');
 
-  await triggerEvent(tooltipHelpers.TOOLTIP_SELECTOR, 'mouseleave');
-  await waitForAnimations(tooltipHelpers.TOOLTIP_SELECTOR);
+  // Trigger the event manually so that we can trigger mouseenter on the
+  // tooltip content before it finishes closing
+  triggerEvent(tooltip.scope, 'mouseleave');
+  await triggerEvent(tooltip.content.scope, 'mouseenter');
 
-  assert.equal(tooltipHelpers.getTooltipsCount(), 0,
-    'tooltip removed after exiting the tooltip box');
-});
+  assert.ok(tooltip.isOpen, 'tooltip is still rendered');
 
-test('tooltip box correctly renders content', async function(assert) {
-  assert.expect(1);
+  await triggerEvent(tooltip.content.scope, 'mouseleave');
 
-  this.render(hbs`
-    <div data-test-tooltip-target>
-      Target
-      {{#ice-tooltip}}
-        template block text
-      {{/ice-tooltip}}
-    </div>
-  `);
-
-  await tooltipHelpers.openTooltip('[data-test-tooltip-target]');
-  await waitForAnimations(tooltipHelpers.TOOLTIP_SELECTOR);
-
-  assert.equal(tooltipHelpers.getTooltip().textContent.trim(), 'template block text',
-    'tooltip renders given content');
+  assert.ok(!tooltip.isOpen, 'tooltip removed after exiting the content');
 });
 
 test('tooltip box modifier class can be added', async function(assert) {
   assert.expect(1);
 
   this.render(hbs`
-    <div data-test-tooltip-target>
+    <div>
       Target
-      {{#ice-tooltip class="error-tooltip"}}
+      {{#ice-tooltip data-test-tooltip=true class="error-tooltip"}}
         template block text
       {{/ice-tooltip}}
     </div>
   `);
 
-  await tooltipHelpers.openTooltip('[data-test-tooltip-target]');
-  await waitForAnimations(tooltipHelpers.TOOLTIP_SELECTOR);
+  const tooltip = TooltipHelper.extend({
+    content: {
+      isErrored: hasClass('error-tooltip')
+    }
+  }).create();
 
-  assert.equal(tooltipHelpers.getTooltip().classList.contains('error-tooltip'), true,
-    'tooltip box reflects additional class');
+  await tooltip.open();
+
+  assert.ok(tooltip.content.isErrored, 'tooltip box reflects additional class');
 });
 
 test('tooltip box direction can be modified', async function(assert) {
   assert.expect(1);
 
   this.render(hbs`
-    <div data-test-tooltip-target>
+    <div>
       Target
-      {{#ice-tooltip placement="bottom-end"}}
+      {{#ice-tooltip data-test-tooltip=true placement="bottom-end"}}
         template block text
       {{/ice-tooltip}}
     </div>
   `);
 
-  await tooltipHelpers.openTooltip('[data-test-tooltip-target]');
-  await waitForAnimations(tooltipHelpers.TOOLTIP_SELECTOR);
+  const tooltip = TooltipHelper.create();
 
-  assert.equal(tooltipHelpers.getTooltip().getAttribute('x-placement'), 'bottom-end',
-    'tooltip box reflects correct direction');
+  await tooltip.open();
+
+  assert.equal(tooltip.content.placement, 'bottom-end', 'tooltip box reflects correct direction');
+});
+
+test('tooltip trigger element is marked as active when open', async function(assert) {
+  assert.expect(3);
+
+  this.render(hbs`
+    <div>
+      Target
+      {{#ice-tooltip data-test-tooltip=true placement="bottom-end"}}
+        template block text
+      {{/ice-tooltip}}
+    </div>
+  `);
+
+  const tooltip = TooltipHelper.create();
+
+  assert.ok(!tooltip.trigger.isActive, 'tooltip trigger is not marked as active when the tooltip is closed');
+
+  await tooltip.open();
+
+  assert.ok(tooltip.trigger.isActive, 'tooltip trigger is marked as active when the tooltip is open');
+
+  await tooltip.close();
+
+  assert.ok(!tooltip.trigger.isActive, 'tooltip trigger is not marked as active when the tooltip is closed again');
 });

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -4,5 +4,11 @@ import {
 } from 'ember-qunit';
 import { start } from 'ember-cli-qunit';
 
+import { useNativeDOMHelpers } from 'ember-cli-page-object/extend';
+import registerWaiter from 'ember-raf-scheduler/test-support/register-waiter';
+
+useNativeDOMHelpers();
+registerWaiter();
+
 setResolver(resolver);
 start();

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,11 +10,13 @@
     eslint-plugin-ember-suave "^1.0.0"
     eslint-plugin-import "^2.3.0"
 
-"@addepar/ice-box@^0.1.0":
-  version "0.1.0"
-  resolved "https://addepar.jfrog.io/addepar/api/npm/npm/@addepar/ice-box/-/@addepar/ice-box-0.1.0.tgz#5c0d76e1282949a3f08e58188fbde3f221ba1d37"
+"@addepar/ice-box@^0.1.1":
+  version "0.1.1"
+  resolved "https://addepar.jfrog.io/addepar/api/npm/npm/@addepar/ice-box/-/@addepar/ice-box-0.1.1.tgz#fbac16d49b19e75987ae133ec45d5cbe8026a56b"
   dependencies:
     ember-cli-babel "^6.3.0"
+    ember-cli-version-checker "^2.1.0"
+    ember-hash-helper-polyfill "^0.2.0"
 
 "@addepar/sass-lint-config@^1.0.0":
   version "1.0.0"
@@ -1809,6 +1811,10 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
 
+ceibo@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ceibo/-/ceibo-2.0.0.tgz#9a61eb054a91c09934588d4e45d9dd2c3bf04eee"
+
 center-align@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/center-align/-/center-align-0.1.3.tgz#aa0d32629b6ee972200411cbd4461c907bc2b7ad"
@@ -2448,6 +2454,14 @@ ember-argument-decorators@~0.6.1:
     ember-compatibility-helpers "^0.1.1"
     ember-get-config "^0.2.3"
 
+ember-classy-page-object@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/ember-classy-page-object/-/ember-classy-page-object-0.1.0.tgz#5557de65ef513be54b4b48441ba214759c74d19b"
+  dependencies:
+    broccoli-funnel "^2.0.1"
+    ember-cli-babel "^6.6.0"
+    ember-cli-page-object pzuraq/ember-cli-page-object#af35424
+
 ember-cli-babel@^5.1.6, ember-cli-babel@^5.1.7:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz#5ce4f46b08ed6f6d21e878619fb689719d6e8e13"
@@ -2627,6 +2641,26 @@ ember-cli-normalize-entity-name@^1.0.0:
   resolved "https://registry.yarnpkg.com/ember-cli-normalize-entity-name/-/ember-cli-normalize-entity-name-1.0.0.tgz#0b14f7bcbc599aa117b5fddc81e4fd03c4bad5b7"
   dependencies:
     silent-error "^1.0.0"
+
+ember-cli-page-object@pzuraq/ember-cli-page-object#af35424:
+  version "1.12.0"
+  resolved "https://codeload.github.com/pzuraq/ember-cli-page-object/tar.gz/af35424841c3d64c693ec576d866798b4bafe604"
+  dependencies:
+    ceibo "~2.0.0"
+    ember-cli-babel "^5.1.7"
+    ember-cli-get-component-path-option "^1.0.0"
+    ember-cli-is-package-missing "^1.0.0"
+    ember-cli-node-assets "^0.2.2"
+    ember-cli-normalize-entity-name "^1.0.0"
+    ember-cli-path-utils "^1.0.0"
+    ember-cli-string-utils "^1.0.0"
+    ember-cli-test-info "^1.0.0"
+    ember-cli-valid-component-name "^1.0.0"
+    ember-cli-version-checker "^1.2.0"
+    ember-native-dom-helpers "^0.5.3"
+    ember-test-helpers "^0.6.3"
+    jquery "^3.2.1"
+    rsvp "^3.2.1"
 
 ember-cli-path-utils@^1.0.0:
   version "1.0.0"
@@ -2847,7 +2881,15 @@ ember-compatibility-helpers@^0.1.1:
     ember-cli-version-checker "^2.0.0"
     semver "^5.4.1"
 
-ember-decorators@^1.3.0, ember-decorators@^1.3.1:
+ember-compatibility-helpers@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-0.1.2.tgz#8eb1769ad761db273fd40242b1170d9f3841d0f0"
+  dependencies:
+    babel-plugin-debug-macros "^0.1.11"
+    ember-cli-version-checker "^2.0.0"
+    semver "^5.4.1"
+
+ember-decorators@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/ember-decorators/-/ember-decorators-1.3.1.tgz#00027da711c200bdeaf9e572ea3d96957e13013d"
   dependencies:
@@ -2882,9 +2924,16 @@ ember-hash-helper-polyfill@^0.1.2:
     ember-cli-babel "^5.1.7"
     ember-cli-version-checker "^1.2.0"
 
-ember-legacy-class-transform@~0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/ember-legacy-class-transform/-/ember-legacy-class-transform-0.1.2.tgz#f09e1b002ac4141096051a4ce387ba6828eddb16"
+ember-hash-helper-polyfill@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/ember-hash-helper-polyfill/-/ember-hash-helper-polyfill-0.2.0.tgz#0913a06ad59147f345dff0edda04b112deba0f7e"
+  dependencies:
+    ember-cli-babel "^6.8.2"
+    ember-cli-version-checker "^1.2.0"
+
+ember-legacy-class-transform@^0.1.3, ember-legacy-class-transform@~0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/ember-legacy-class-transform/-/ember-legacy-class-transform-0.1.3.tgz#af943fd46aa050981b7f0927bf70ef8736878682"
   dependencies:
     babel-plugin-ember-legacy-class-constructor "^0.1.4"
     ember-cli-babel "^6.3.0"
@@ -2914,25 +2963,29 @@ ember-maybe-import-regenerator@^0.1.6:
     ember-cli-babel "^6.0.0-beta.4"
     regenerator-runtime "^0.9.5"
 
-ember-native-dom-helpers@^0.5.0:
+ember-native-dom-helpers@^0.5.0, ember-native-dom-helpers@^0.5.3:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/ember-native-dom-helpers/-/ember-native-dom-helpers-0.5.4.tgz#0bc1506a643fb7adc0abf1d09c44a7914459296b"
   dependencies:
     broccoli-funnel "^1.1.0"
     ember-cli-babel "^6.6.0"
 
-ember-popper@~0.6.6:
-  version "0.6.6"
-  resolved "https://registry.yarnpkg.com/ember-popper/-/ember-popper-0.6.6.tgz#857c521fae024eab06ccafe0bad3f02ecf1aa4a6"
+ember-popper@^0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/ember-popper/-/ember-popper-0.7.1.tgz#7bcca64e18167d7a69bec21da0a7770b5c482d1d"
   dependencies:
     babel-eslint "^8.0.1"
     babel6-plugin-strip-class-callcheck "^6.0.0"
     broccoli-funnel "^2.0.0"
+    ember-argument-decorators "~0.6.1"
     ember-cli-babel "^6.8.2"
     ember-cli-htmlbars "^2.0.3"
     ember-cli-node-assets "^0.2.2"
     ember-cli-version-checker "^2.1.0"
-    ember-decorators "^1.3.0"
+    ember-compatibility-helpers "^0.1.2"
+    ember-decorators "^1.3.1"
+    ember-legacy-class-transform "^0.1.3"
+    ember-raf-scheduler "^0.1.0"
     fastboot-transform "^0.1.0"
     popper.js "^1.12.5"
 
@@ -2941,6 +2994,12 @@ ember-qunit@^2.2.0:
   resolved "https://registry.yarnpkg.com/ember-qunit/-/ember-qunit-2.2.0.tgz#3cdf400031c93a38de781a7304819738753b7f99"
   dependencies:
     ember-test-helpers "^0.6.3"
+
+ember-raf-scheduler@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/ember-raf-scheduler/-/ember-raf-scheduler-0.1.0.tgz#a22a02d238c374499231c03ab9c5b9887c72a853"
+  dependencies:
+    ember-cli-babel "^6.6.0"
 
 ember-resolver@^4.0.0:
   version "4.5.0"
@@ -2997,9 +3056,9 @@ ember-test-helpers@^0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/ember-test-helpers/-/ember-test-helpers-0.6.3.tgz#f864cdf6f4e75f3f8768d6537785b5ab6e82d907"
 
-ember-test-selectors@pzuraq/ember-test-selectors#24334cd9a0de17a4201c5354f8b4cd9ea774c208:
+ember-test-selectors@simplabs/ember-test-selectors#251be25:
   version "0.3.7"
-  resolved "https://codeload.github.com/pzuraq/ember-test-selectors/tar.gz/24334cd9a0de17a4201c5354f8b4cd9ea774c208"
+  resolved "https://codeload.github.com/simplabs/ember-test-selectors/tar.gz/251be253890f62b57b3b19487426ef58711c616b"
   dependencies:
     broccoli-stew "^1.4.0"
     ember-cli-babel "^6.8.2"


### PR DESCRIPTION
Apologies in advance for the large PR, the testing methods were pretty tightly coupled to implementation so it was hard to break this apart. Happy to do a pair review with someone on it.

This refactor does the following:

1. Normalizes all of the popover components into a single base-popover component. The similarities between popovers, tooltips, and dropdowns are pretty large, so rather than having separate component classes it makes sense to have a single component which can handle the variations, and have subclasses that can provide defaults.

2. Allows transitions to be any length, including 0s. This allows us to turn them off during testing by overriding the `.ice-animated` CSS class

3. Moves usage of RAF to ember-raf-scheduler which allows us to wait on tests properly

4. Reduces the scope of the public API in the following ways:
  - Users can no longer provide a custom target, only the parent element is used
  - `data-close` attributes will no longer be added automatically, they must be manually added to items

5. Creates and exports a set of PageObjects based on ember-classy-page-object that wrap the components and allow users to write tests for them without being tied to implementation details.

TODO:
- [x] Make sure all new components are fully commented/documented
- [x] Document PageObjects - This could be tricky, since they aren't class based and ES doc is not a fan of that.