### PR TITLE
Lydia/remove dropdowns caret

### DIFF
--- a/addon/components/ice-dropdown.js
+++ b/addon/components/ice-dropdown.js
@@ -10,7 +10,7 @@ import layout from '../templates/components/ice-dropdown';
  * ```hbs
  * <div class="target">
  *   Target text
- *   <div class="ice-dropdown-caret"></div>
+ *   <i class="fa fa-caret-down ice-dropdown-caret"></i>
  *   {{#ice-dropdown}}
  *     Dropdown with defaults
  *   {{/ice-dropdown}}
@@ -18,7 +18,7 @@ import layout from '../templates/components/ice-dropdown';
  *
  * <div class="target">
  *   Target text
- *   <div class="ice-dropdown-caret"></div>
+ *   <i class="fa fa-caret-down ice-dropdown-caret"></i>
  *   {{#ice-dropdown placement="bottom"}}
  *     Dropdown with custom placement
  *   {{/ice-dropdown}}
@@ -26,7 +26,7 @@ import layout from '../templates/components/ice-dropdown';
  *
  * <div class="target">
  *   Target text
- *   <div class="ice-dropdown-caret"></div>
+ *   <i class="fa fa-caret-down ice-dropdown-caret"></i>
  *   {{#ice-dropdown class="custom-class"}}
  *     Dropdown with custom class
  *   {{/ice-tooltip}}
@@ -34,7 +34,7 @@ import layout from '../templates/components/ice-dropdown';
  *
  * <div class="target">
  *   Target text
- *   <div class="ice-dropdown-caret"></div>
+ *   <i class="fa fa-caret-down ice-dropdown-caret"></i>
  *   {{#ice-dropdown}}
  *     <a data-close>
  *       Adding data-close to anything within the dropdown will cause

--- a/addon/components/ice-sub-dropdown.js
+++ b/addon/components/ice-sub-dropdown.js
@@ -11,7 +11,7 @@ import IceDropdownComponent from './ice-dropdown';
  *   <ul class="ice-dropdown-menu">
  *     <li>
  *       <a>Foo bar baz</a>
- *       <div class="ice-dropdown-caret"></div>
+ *       <i class="fa fa-caret-down ice-dropdown-caret"></i>
  *       {{#ice-sub-dropdown}}
  *         <ul class="ice-dropdown-menu">
  *           <li><a>Foo bar baz</a></li>

--- a/app/styles/ice-pop/dropdown/_dropdown_menu.scss
+++ b/app/styles/ice-pop/dropdown/_dropdown_menu.scss
@@ -7,7 +7,8 @@
 // However you should only use it inside the ice-dropdown Ember addon like this:
 // ```
 // <div class="example-target">
-//   Target text <div class="ice-dropdown-caret"></div>
+//   Target text
+//   <i class="fa fa-caret-down ice-dropdown-caret"></i>
 //   {{#ice-dropdown}}
 //     <ul class="ice-dropdown-menu">
 //       <li><a {{action 'foo'}}>Foo bar baz</a></li>
@@ -38,7 +39,8 @@
 //   use the ember addon as notated in the section above)
 //   <div class="dropdown-example">
 //     <div class="example-target ice-dropdown-toggle" dropdown-placement="bottom-start">
-//       Target text <div class="ice-dropdown-caret"></div>
+//       Target text
+//       <i class="fa fa-caret-down ice-dropdown-caret"></i>
 //       <div class="ice-dropdown is-visible" x-placement="bottom-start">
 //         <ul class="ice-dropdown-menu">
 //           <li><a data-dropdown-close>Foo bar baz</a></li>

--- a/app/styles/ice-pop/dropdown/_dropdown_menu.scss
+++ b/app/styles/ice-pop/dropdown/_dropdown_menu.scss
@@ -104,7 +104,7 @@
       opacity: 0.6; // TODO: update to $disabled-opacity; from ice-box
     }
 
-    // TODO: investigate if this will cause any issues
+    // TODO: investigate if this will cause any issues in Iverson
     .ice-dropdown-caret {
       @include anchor-element($top: 50%, $right: $ice-dropdown-item-spacing-horizontal / 2);
       transform: translateY(-50%);
@@ -120,35 +120,5 @@
       font-weight: $ice-dropdown-item-group-header-weight;
       padding: $ice-dropdown-item-spacing-vertical $ice-dropdown-item-spacing-horizontal;
     }
-  }
-}
-
-
-// TODO: The caret here is currently temporary for development.
-// Update this whole section with font awesome (when it makes it to ice-box) BEFORE using in Iverson.
-.ice-dropdown-caret {
-  display: inline-block;
-  margin-left: $spacing-small;
-
-  &::after {
-    content: '\0203A';
-    display: block;
-    color: inherit;
-  }
-
-  .ice-dropdown-toggle[dropdown-placement^="right"] > & {
-    // nothing
-  }
-
-  .ice-dropdown-toggle[dropdown-placement^="left"] > & {
-    transform: rotate(180deg);
-  }
-
-  .ice-dropdown-toggle[dropdown-placement^="bottom"] > & {
-    transform: rotate(90deg);
-  }
-
-  .ice-dropdown-toggle[dropdown-placement^="top"] > & {
-    transform: rotate(-90deg);
   }
 }

--- a/app/styles/ice-pop/dropdown/_sub_dropdown.scss
+++ b/app/styles/ice-pop/dropdown/_sub_dropdown.scss
@@ -10,7 +10,7 @@
 //   <ul class="ice-dropdown-menu">
 //     <li>
 //       <a>Foo bar baz</a>
-//       <div class="ice-dropdown-caret"></div>
+//       <i class="fa fa-caret-down ice-dropdown-caret"></i>
 //       {{#ice-sub-dropdown}}
 //         <ul class="ice-dropdown-menu">
 //           <li><a>Foo bar baz</a></li>
@@ -34,12 +34,13 @@
 // Markup:
 //   <div class="dropdown-example">
 //     <div class="example-target ice-dropdown-toggle" dropdown-placement="bottom">
-//       Target text <div class="ice-dropdown-caret"></div>
+//       Target text
+//       <i class="fa fa-caret-down ice-dropdown-caret"></i>
 //       <div class="ice-dropdown is-visible">
 //         <ul class="ice-dropdown-menu">
 //           <li>
 //             <a class="is-active">Foo bar baz</a>
-//             <div class="ice-dropdown-caret"></div>
+//             <i class="fa fa-caret-down ice-dropdown-caret"></i>
 //             <div class="ice-dropdown ice-sub-dropdown is-visible" x-placement="right-start">
 //               <div class="ice-dropdown-content">
 //                 <ul class="ice-dropdown-menu">

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -70,3 +70,33 @@ $demo-container-width: 400px;
 .popover-target {
   margin: 20px;
 }
+
+
+// TODO: The caret here is currently temporary for development.
+// Update this with font awesome when it is finally included in ice-box.
+.ice-dropdown-caret {
+  display: inline-block;
+  margin-left: $spacing-small;
+
+  &::after {
+    content: '\0203A';
+    display: block;
+    color: inherit;
+  }
+
+  &.right {
+    // nothing
+  }
+
+  &.left {
+    transform: rotate(180deg);
+  }
+
+  &.down {
+    transform: rotate(90deg);
+  }
+
+  &.up {
+    transform: rotate(-90deg);
+  }
+}

--- a/tests/dummy/app/templates/dropdown.hbs
+++ b/tests/dummy/app/templates/dropdown.hbs
@@ -4,7 +4,7 @@
 <div class="demo-container">
   <div class="demo-item">
     <button class="button-text popover-target">
-      Bottom Middle <div class="ice-dropdown-caret"></div>
+      Bottom Middle <div class="ice-dropdown-caret down"></div>
       {{#ice-dropdown placement='bottom'}}
         <ul class="ice-dropdown-menu">
           <li><a>Foo bar baz</a></li>
@@ -19,7 +19,7 @@
   </div>
   <div class="demo-item">
     <button class="button-text popover-target">
-      Bottom Right (default) <div class="ice-dropdown-caret"></div>
+      Bottom Right (default) <div class="ice-dropdown-caret down"></div>
       {{#ice-dropdown}}
         <ul class="ice-dropdown-menu">
           <li><a>Foo bar baz</a></li>
@@ -34,7 +34,7 @@
   </div>
   <div class="demo-item">
     <button class="button-text popover-target">
-      Bottom Left <div class="ice-dropdown-caret"></div>
+      Bottom Left <div class="ice-dropdown-caret down"></div>
       {{#ice-dropdown placement='bottom-end'}}
         <ul class="ice-dropdown-menu">
           <li><a>Foo bar baz</a></li>
@@ -50,7 +50,7 @@
 
   <div class="demo-item">
     <button class="button-text popover-target">
-      Top Middle <div class="ice-dropdown-caret"></div>
+      Top Middle <div class="ice-dropdown-caret up"></div>
       {{#ice-dropdown placement='top'}}
         <ul class="ice-dropdown-menu">
           <li><a>Foo bar baz</a></li>
@@ -65,7 +65,7 @@
   </div>
   <div class="demo-item">
     <button class="button-text popover-target">
-      Top Right <div class="ice-dropdown-caret"></div>
+      Top Right <div class="ice-dropdown-caret up"></div>
       {{#ice-dropdown placement='top-start'}}
         <ul class="ice-dropdown-menu">
           <li><a>Foo bar baz</a></li>
@@ -80,7 +80,7 @@
   </div>
   <div class="demo-item">
     <button class="button-text popover-target">
-      Top Left <div class="ice-dropdown-caret"></div>
+      Top Left <div class="ice-dropdown-caret up"></div>
       {{#ice-dropdown placement='top-end'}}
         <ul class="ice-dropdown-menu">
           <li><a>Foo bar baz</a></li>
@@ -96,7 +96,7 @@
 
   <div class="demo-item">
     <button class="button-text popover-target">
-      Right Middle <div class="ice-dropdown-caret"></div>
+      Right Middle <div class="ice-dropdown-caret right"></div>
       {{#ice-dropdown placement='right'}}
         <ul class="ice-dropdown-menu">
           <li><a>Foo bar baz</a></li>
@@ -111,7 +111,7 @@
   </div>
   <div class="demo-item">
     <button class="button-text popover-target">
-      Right Bottom <div class="ice-dropdown-caret"></div>
+      Right Bottom <div class="ice-dropdown-caret right"></div>
       {{#ice-dropdown placement='right-start'}}
         <ul class="ice-dropdown-menu">
           <li><a>Foo bar baz</a></li>
@@ -126,7 +126,7 @@
   </div>
   <div class="demo-item">
     <button class="button-text popover-target">
-      Right Top <div class="ice-dropdown-caret"></div>
+      Right Top <div class="ice-dropdown-caret right"></div>
       {{#ice-dropdown placement='right-end'}}
         <ul class="ice-dropdown-menu">
           <li><a>Foo bar baz</a></li>
@@ -142,7 +142,7 @@
 
   <div class="demo-item">
     <button class="button-text popover-target">
-      Left Middle <div class="ice-dropdown-caret"></div>
+      Left Middle <div class="ice-dropdown-caret left"></div>
       {{#ice-dropdown placement='left'}}
         <ul class="ice-dropdown-menu">
           <li><a>Foo bar baz</a></li>
@@ -157,7 +157,7 @@
   </div>
   <div class="demo-item">
     <button class="button-text popover-target">
-      Left Bottom <div class="ice-dropdown-caret"></div>
+      Left Bottom <div class="ice-dropdown-caret left"></div>
       {{#ice-dropdown placement='left-start'}}
         <ul class="ice-dropdown-menu">
           <li><a>Foo bar baz</a></li>
@@ -172,7 +172,7 @@
   </div>
   <div class="demo-item">
     <button class="button-text popover-target">
-      Left Top <div class="ice-dropdown-caret"></div>
+      Left Top <div class="ice-dropdown-caret left"></div>
       {{#ice-dropdown placement='left-end'}}
         <ul class="ice-dropdown-menu">
           <li><a>Foo bar baz</a></li>
@@ -195,7 +195,7 @@
 
   <div class="demo-item">
     <button class="button-icon popover-target">
-      + <div class="ice-dropdown-caret"></div>
+      + <div class="ice-dropdown-caret down"></div>
       {{#ice-dropdown}}
         <ul class="ice-dropdown-menu">
           <li><a>Foo bar baz</a></li>
@@ -210,7 +210,7 @@
   </div>
   <div class="demo-item">
     <button class="button-default popover-target">
-      Button default <div class="ice-dropdown-caret"></div>
+      Button default <div class="ice-dropdown-caret down"></div>
       {{#ice-dropdown}}
         <ul class="ice-dropdown-menu">
           <li><a>Foo bar baz</a></li>
@@ -225,7 +225,7 @@
   </div>
   <div class="demo-item">
     <button class="button-link popover-target">
-      Button link <div class="ice-dropdown-caret"></div>
+      Button link <div class="ice-dropdown-caret down"></div>
       {{#ice-dropdown}}
         <ul class="ice-dropdown-menu">
           <li><a>Foo bar baz</a></li>
@@ -246,7 +246,7 @@
 
   <div class="demo-item">
     <button class="button-text popover-target">
-      Divider <div class="ice-dropdown-caret"></div>
+      Divider <div class="ice-dropdown-caret down"></div>
       {{#ice-dropdown}}
         <ul class="ice-dropdown-menu">
           <li><a>Foo bar baz</a></li>
@@ -262,7 +262,7 @@
   </div>
   <div class="demo-item">
     <button class="button-text popover-target">
-      Selected item <div class="ice-dropdown-caret"></div>
+      Selected item <div class="ice-dropdown-caret down"></div>
       {{#ice-dropdown}}
         <ul class="ice-dropdown-menu">
           <li><a>Foo bar baz</a></li>
@@ -277,7 +277,7 @@
   </div>
   <div class="demo-item">
     <button class="button-text popover-target">
-      Disabled item<div class="ice-dropdown-caret"></div>
+      Disabled item<div class="ice-dropdown-caret down"></div>
       {{#ice-dropdown}}
         <ul class="ice-dropdown-menu">
           <li><a>Foo bar baz</a></li>
@@ -292,7 +292,7 @@
   </div>
   <div class="demo-item">
     <button class="button-text popover-target">
-      Group Header <div class="ice-dropdown-caret"></div>
+      Group Header <div class="ice-dropdown-caret down"></div>
       {{#ice-dropdown}}
         <ul class="ice-dropdown-menu">
           <li class="list-group-header">Group Header</li>
@@ -309,7 +309,7 @@
   </div>
   <div class="demo-item">
     <button class="button-text popover-target">
-      Custom Class <div class="ice-dropdown-caret"></div>
+      Custom Class <div class="ice-dropdown-caret down"></div>
       {{#ice-dropdown class="foobar"}}
         <ul class="ice-dropdown-menu">
           <li><a>Foo bar baz</a></li>
@@ -324,14 +324,14 @@
   </div>
   <div class="demo-item">
     <button class="button-text popover-target">
-      Submenu <div class="ice-dropdown-caret"></div>
+      Submenu <div class="ice-dropdown-caret down"></div>
       {{#ice-dropdown}}
         <ul class="ice-dropdown-menu">
           <li><a>Foo bar baz</a></li>
           <li><a>Lorem ipsum</a></li>
           <li>
             <a>I'm Mr. Meseeks</a>
-            <div class="ice-dropdown-caret"></div>
+            <div class="ice-dropdown-caret right"></div>
             {{#ice-sub-dropdown}}
               <ul class="ice-dropdown-menu">
                 <li><a>Foo bar baz</a></li>
@@ -358,7 +358,7 @@
 
   <div class="demo-item">
     <button class="button-text popover-target">
-      Long menu items<div class="ice-dropdown-caret"></div>
+      Long menu items<div class="ice-dropdown-caret down"></div>
       {{#ice-dropdown}}
         <ul class="ice-dropdown-menu">
           <li><a>Foo bar baz</a></li>
@@ -373,12 +373,12 @@
   </div>
   <div class="demo-item">
     <button class="button-text popover-target">
-      Long menu items with caret <div class="ice-dropdown-caret"></div>
+      Long menu items with caret <div class="ice-dropdown-caret down"></div>
       {{#ice-dropdown}}
         <ul class="ice-dropdown-menu">
           <li><a>Foo bar baz</a></li>
           <li><a>Lorem ipsum</a></li>
-          <li><a>Lorem ipsum dolor sit amet supcalifragalisticecspialdocious</a> <div class="ice-dropdown-caret"></div>
+          <li><a>Lorem ipsum dolor sit amet supcalifragalisticecspialdocious</a> <div class="ice-dropdown-caret right"></div>
           {{#ice-sub-dropdown}}
             <ul class="ice-dropdown-menu">
               <li><a>Foo bar baz</a></li>
@@ -399,7 +399,7 @@
   </div>
   <div class="demo-item">
     <button class="button-text popover-target">
-      Lots of items <div class="ice-dropdown-caret"></div>
+      Lots of items <div class="ice-dropdown-caret down"></div>
       {{#ice-dropdown}}
         <ul class="ice-dropdown-menu">
           <li><a>Foo bar baz</a></li>


### PR DESCRIPTION
The caret styling I was using before was temporary bc we don't have font awesome yet. I moved it to the dummy app css since we don't actually want that in the core dropdown css. I also updated the docs to show the correct font awesome usage bc it is more accurate for our devs.

@Addepar/ice 