### PR TITLE
refactor(page-object): Finalizing some public API stuff with PageObject

### DIFF
--- a/addon-test-support/pages/-private/base-pop-menu.js
+++ b/addon-test-support/pages/-private/base-pop-menu.js
@@ -1,15 +1,14 @@
 import Ceibo from 'ceibo';
 
 import PageObject, { attribute, hasClass } from 'ember-classy-page-object';
-
-import { find } from 'ember-native-dom-helpers';
+import { findElement } from 'ember-classy-page-object/extend';
 
 /**
  * Base test page-object for ice-tooltip, ice-popover, ice-dropdown, and ice-sub-dropdown.
  * Allows testers to open ond close the popover and select its content, as well as check
  * its current state.
  */
-export default new PageObject({
+export default PageObject.extend({
   /**
    * Opens the popover using the method provided by the subclass on the trigger element
    *
@@ -41,7 +40,7 @@ export default new PageObject({
   trigger: {
     resetScope: true,
     get scope() {
-      const parent = find(Ceibo.parent(this).scope);
+      const parent = findElement(Ceibo.parent(this));
 
       // The parent may not be rendered either, so we can only grab the ID if it exists
       const parentId = parent ? parent.getAttribute('id') : 'unrendered';
@@ -61,7 +60,7 @@ export default new PageObject({
   content: {
     resetScope: true,
     get scope() {
-      const parent = find(Ceibo.parent(this).scope);
+      const parent = findElement(Ceibo.parent(this));
 
       // The parent may not be rendered either, so we can only grab the ID if it exists
       const parentId = parent ? parent.getAttribute('id') : 'unrendered';

--- a/addon-test-support/pages/ice-tooltip-icon.js
+++ b/addon-test-support/pages/ice-tooltip-icon.js
@@ -1,15 +1,14 @@
 import PageObject from 'ember-classy-page-object';
+import { findElement } from 'ember-classy-page-object/extend';
 
 import TooltipPage from './ice-tooltip';
 
-import { find } from 'ember-native-dom-helpers';
-
-export default new PageObject({
+export default PageObject.extend({
   /**
    * Returns if this tooltip-icon is the specified icon
    */
   isIcon(icon) {
-    return find(this.scope).classList.contains(icon);
+    return findElement(this).classList.contains(icon);
   },
 
   /**

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@addepar/ice-box": "^0.1.3",
     "ember-argument-decorators": "~0.6.1",
-    "ember-classy-page-object": "^0.2.1",
+    "ember-classy-page-object": "^0.3.0",
     "ember-cli-babel": "^6.6.0",
     "ember-cli-htmlbars": "^2.0.1",
     "ember-decorators": "^1.3.1",
@@ -52,7 +52,7 @@
     "ember-native-dom-helpers": "^0.5.0",
     "ember-resolver": "^4.0.0",
     "ember-source": "~2.16.0",
-    "ember-test-selectors": "simplabs/ember-test-selectors#251be25",
+    "ember-test-selectors": "^0.3.8",
     "loader.js": "^4.2.3"
   },
   "engines": {

--- a/tests/integration/components/ice-dropdown-test.js
+++ b/tests/integration/components/ice-dropdown-test.js
@@ -52,7 +52,7 @@ test('dropdown box closes when element outside of dropdown is clicked', async fu
     </div>
   `);
 
-  const content = new PageObject({
+  const content = PageObject.extend({
     scope: '[data-test-content]',
     clickOutsideElement: clickable('[data-test-outside-element]'),
 

--- a/tests/integration/components/ice-popover-test.js
+++ b/tests/integration/components/ice-popover-test.js
@@ -52,7 +52,7 @@ test('popover box closes when element outside of popover is clicked', async func
     </div>
   `);
 
-  const content = new PageObject({
+  const content = PageObject.extend({
     scope: '[data-test-content]',
     clickOutsideElement: clickable('[data-test-outside-element]'),
 

--- a/tests/integration/components/ice-sub-dropdown-test.js
+++ b/tests/integration/components/ice-sub-dropdown-test.js
@@ -106,7 +106,7 @@ test('sub dropdown box closes when element outside of sub dropdown is clicked', 
     </div>
   `);
 
-  const content = new PageObject({
+  const content = PageObject.extend({
     scope: '[data-test-content]',
     clickOutsideElement: clickable('[data-test-outside-element]'),
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2407,9 +2407,9 @@ ember-argument-decorators@~0.6.1:
     ember-compatibility-helpers "^0.1.1"
     ember-get-config "^0.2.3"
 
-ember-classy-page-object@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/ember-classy-page-object/-/ember-classy-page-object-0.2.1.tgz#ee895d211933b2b70adf50f80444c6ad4c69fb50"
+ember-classy-page-object@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/ember-classy-page-object/-/ember-classy-page-object-0.3.0.tgz#57ae2d8ec1deb57eb330e7c91f7c75d9158f6d53"
   dependencies:
     broccoli-funnel "^2.0.1"
     ember-cli-babel "^6.6.0"
@@ -2948,9 +2948,9 @@ ember-test-helpers@^0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/ember-test-helpers/-/ember-test-helpers-0.6.3.tgz#f864cdf6f4e75f3f8768d6537785b5ab6e82d907"
 
-ember-test-selectors@simplabs/ember-test-selectors#251be25:
-  version "0.3.7"
-  resolved "https://codeload.github.com/simplabs/ember-test-selectors/tar.gz/251be253890f62b57b3b19487426ef58711c616b"
+ember-test-selectors@^0.3.8:
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/ember-test-selectors/-/ember-test-selectors-0.3.8.tgz#1e8ae3e78c64bacc4bbfe87f9973c85805699db2"
   dependencies:
     broccoli-stew "^1.4.0"
     ember-cli-babel "^6.8.2"


### PR DESCRIPTION
Finalizes the public API of classy page object, normalizing from `new` to always using `.extend`