### PR TITLE
bugfix(animation): Wrap async transition-end handler in runloop

### DIFF
--- a/addon/components/-private/animated-popper.js
+++ b/addon/components/-private/animated-popper.js
@@ -156,7 +156,7 @@ export default class AnimatedPopperComponent extends Component {
         // important in tests
         raf.schedule('affect', () => {
           if (this.get('makeVisible') === false) {
-            run(() => this.finalizeClose());
+            this.finalizeClose();
           }
         }, this._token);
       }
@@ -188,15 +188,17 @@ export default class AnimatedPopperComponent extends Component {
    * and notifies the parent context that animations have finished.
    */
   finalizeClose() {
-    this.set('renderInDOM', false);
+    run(() => {
+      this.set('renderInDOM', false);
 
-    if (this._hasTransition) {
-      this._animatedElement.removeEventListener('transitionend', this._transitionEndHandler);
-    }
+      if (this._hasTransition) {
+        this._animatedElement.removeEventListener('transitionend', this._transitionEndHandler);
+      }
 
-    this._animatedElement = null;
+      this._animatedElement = null;
 
-    this.sendAction('onClose');
+      this.sendAction('onClose');
+    });
   }
 
   // ----- Event Handlers -----


### PR DESCRIPTION
We didn't catch this in testing because we turn off animations, but the transition-end handler runs asynchronously so any actions that could schedule anything should be wrapped in a runloop

cc @Addepar/ice 