### PR TITLE
Update popper first item autofocus to only happen in keyboard mode

### DIFF
--- a/addon/components/-private/base-pop-menu.js
+++ b/addon/components/-private/base-pop-menu.js
@@ -240,12 +240,6 @@ export default class BasePopMenuComponent extends Component {
       this._popperElement.addEventListener('focus', this._openPopoverHandler);
       this._popperElement.addEventListener('blur', this._closePopoverBlurHandler);
     }
-
-    // Wait until popper layout has finished computing, otherwise the mischief will happen
-    raf.schedule('layout', () => {
-      // Automatically focus on first focusable item in the popper
-      this._focusOnFirstFocusableElement();
-    }, this._token);
   }
 
 
@@ -341,6 +335,11 @@ export default class BasePopMenuComponent extends Component {
     // Pressing Enter or Space opens the popper
     if ((keyCode === 'Enter' || keyCode === ' ') && !this.get('isOpen')) {
       this._openPopoverHandler();
+      // Wait until popper layout has finished computing, otherwise mischief will happen
+      raf.schedule('layout', () => {
+        // Automatically focus on first focusable item in the popper
+        this._focusOnFirstFocusableElement();
+      }, this._token);
     } else if ((keyCode === 'Escape' || keyCode === 'Enter') && this.get('isOpen')) {
       // Close on esc if we never entered the popper
       // (Enter is the same as re-clicking the button)

--- a/tests/integration/components/ice-dropdown-test.js
+++ b/tests/integration/components/ice-dropdown-test.js
@@ -263,3 +263,49 @@ test('dropdown is keyboard accessible', async function(assert) {
 
   assert.ok(!dropdown.isOpen, 'dropdown removed after pressing enter on a data-close item');
 });
+
+test('First item autofocuses when opened by keyboard only', async function(assert) {
+  assert.expect(6);
+
+  this.render(hbs`
+    <button>
+      Target
+      {{#ice-dropdown data-test-dropdown=true placement="right-start"}}
+        <ul class="ice-dropdown-menu">
+          <li><button data-test-menu-item>First Item</button></li>
+          <li><button>Another Item</button></li>
+        </ul>
+      {{/ice-dropdown}}
+    </button>
+  `);
+
+  let dropdown = DropdownHelper.extend({
+    trigger: {
+      enter: triggerable('keydown', null, { eventProperties: { key: 'Enter' } }),
+      space: triggerable('keydown', null, { eventProperties: { key: ' ' } })
+    },
+    content: {
+      escape: triggerable('keydown', null, { eventProperties: { key: 'Escape' } }),
+      menuItemWithFocus: {
+        scope: '[data-test-menu-item]:focus'
+      }
+    }
+  }).create();
+
+  await dropdown.trigger.enter();
+
+  assert.ok(dropdown.isOpen, 'dropdown rendered on enter');
+  assert.ok(dropdown.content.menuItemWithFocus.isPresent, 'first menu item has focus');
+
+  await dropdown.content.escape();
+  await dropdown.trigger.space();
+
+  assert.ok(dropdown.isOpen, 'dropdown rendered on space');
+  assert.ok(dropdown.content.menuItemWithFocus.isPresent, 'first menu item has focus');
+
+  await dropdown.content.escape();
+  await dropdown.open();
+
+  assert.ok(dropdown.isOpen, 'dropdown rendered on click');
+  assert.ok(!dropdown.content.menuItemWithFocus.isPresent, 'first menu item does not have focus');
+});

--- a/tests/integration/components/ice-popover-test.js
+++ b/tests/integration/components/ice-popover-test.js
@@ -271,3 +271,47 @@ test('popover is keyboard accessible', async function(assert) {
 
   assert.ok(!popover.isOpen, 'popover removed after pressing enter on a data-close item');
 });
+
+test('First item autofocuses when opened by keyboard only', async function(assert) {
+  assert.expect(6);
+
+  this.render(hbs`
+    <button>
+      Target
+      {{#ice-popover data-test-popover=true placement="bottom-end"}}
+        <button data-test-button data-close>Close</button>
+        <button>Foo</button>
+      {{/ice-popover}}
+    </button>
+  `);
+
+  let popover = PopoverHelper.extend({
+    trigger: {
+      enter: triggerable('keydown', null, { eventProperties: { key: 'Enter' } }),
+      space: triggerable('keydown', null, { eventProperties: { key: ' ' } })
+    },
+    content: {
+      escape: triggerable('keydown', null, { eventProperties: { key: 'Escape' } }),
+      buttonWithFocus: {
+        scope: '[data-test-button]:focus'
+      }
+    }
+  }).create();
+
+  await popover.trigger.enter();
+
+  assert.ok(popover.isOpen, 'popover rendered on enter');
+  assert.ok(popover.content.buttonWithFocus.isPresent, 'first button has focus');
+
+  await popover.content.escape();
+  await popover.trigger.space();
+
+  assert.ok(popover.isOpen, 'popover rendered on space');
+  assert.ok(popover.content.buttonWithFocus.isPresent, 'first button has focus');
+
+  await popover.content.escape();
+  await popover.open();
+
+  assert.ok(popover.isOpen, 'popover rendered on click');
+  assert.ok(!popover.content.buttonWithFocus.isPresent, 'first button does not have focus');
+});


### PR DESCRIPTION
For accessibility, we want the poppers to autofocus on the first item when they are opened. This makes most sense for when you are using the keyboard to get around. However after starting to replace dropdowns in the app, it looks super confusing to autofocus the first item when you click to open it. So I updated the autofocus to only happen when you trigger open with Enter/Space, instead of any time its opened.

@Addepar/ice @billylittlefield 