### PR TITLE
chore(deps): Update legacy shims and @argument

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,13 +18,13 @@
   },
   "dependencies": {
     "@addepar/ice-box": "^0.1.3",
-    "@ember-decorators/argument": "^0.8.8",
+    "@ember-decorators/argument": "^0.8.10",
     "ember-classy-page-object": "^0.4.0",
     "ember-cli-babel": "^6.6.0",
     "ember-cli-htmlbars": "^2.0.1",
     "ember-decorators": "^1.3.3",
-    "ember-legacy-class-transform": "~0.1.3",
-    "ember-popper": "^0.8.0",
+    "ember-legacy-class-shim": "^1.0.0",
+    "ember-popper": "^0.8.3",
     "ember-raf-scheduler": "^0.1.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -82,20 +82,9 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@ember-decorators/argument@^0.8.3":
-  version "0.8.6"
-  resolved "https://registry.yarnpkg.com/@ember-decorators/argument/-/argument-0.8.6.tgz#171ba40e166ee2301e6918c41883d644f4f31650"
-  dependencies:
-    babel-plugin-filter-imports "^1.1.1"
-    broccoli-funnel "^2.0.1"
-    ember-cli-babel "^6.3.0"
-    ember-cli-version-checker "^2.0.0"
-    ember-compatibility-helpers "^0.1.1"
-    ember-get-config "^0.2.3"
-
-"@ember-decorators/argument@^0.8.8":
-  version "0.8.8"
-  resolved "https://registry.yarnpkg.com/@ember-decorators/argument/-/argument-0.8.8.tgz#d14d9004337cf1043802bec75c4bd0f0c19f20ff"
+"@ember-decorators/argument@^0.8.10":
+  version "0.8.10"
+  resolved "https://registry.yarnpkg.com/@ember-decorators/argument/-/argument-0.8.10.tgz#c48af0c5c57b5ef3022eba1ce5797a18d1edb6eb"
   dependencies:
     babel-plugin-filter-imports "^1.1.1"
     broccoli-funnel "^2.0.1"
@@ -713,10 +702,6 @@ babel-plugin-debug-macros@^0.1.10, babel-plugin-debug-macros@^0.1.11:
   resolved "https://registry.yarnpkg.com/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.1.11.tgz#6c562bf561fccd406ce14ab04f42c218cf956605"
   dependencies:
     semver "^5.3.0"
-
-babel-plugin-ember-legacy-class-constructor@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/babel-plugin-ember-legacy-class-constructor/-/babel-plugin-ember-legacy-class-constructor-0.1.4.tgz#dfe715b9bdb66f6c7e9eccc620137c03b3fa89e0"
 
 babel-plugin-ember-modules-api-polyfill@^2.3.0:
   version "2.3.0"
@@ -2950,12 +2935,10 @@ ember-hash-helper-polyfill@^0.2.0:
     ember-cli-babel "^6.8.2"
     ember-cli-version-checker "^2.1.0"
 
-ember-legacy-class-transform@^0.1.4, ember-legacy-class-transform@~0.1.3:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/ember-legacy-class-transform/-/ember-legacy-class-transform-0.1.4.tgz#0dd588b8561a4d31c080d5d7ada64521365b3806"
+ember-legacy-class-shim@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ember-legacy-class-shim/-/ember-legacy-class-shim-1.0.0.tgz#569afce1419d3075e41b324fbf8195f6493e3396"
   dependencies:
-    babel-plugin-ember-legacy-class-constructor "^0.1.4"
-    ember-cli-babel "^6.3.0"
     ember-cli-version-checker "^2.0.0"
 
 ember-load-initializers@^1.0.0:
@@ -2989,11 +2972,12 @@ ember-native-dom-helpers@^0.5.0, ember-native-dom-helpers@^0.5.3:
     broccoli-funnel "^1.1.0"
     ember-cli-babel "^6.6.0"
 
-ember-popper@^0.8.0:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/ember-popper/-/ember-popper-0.8.2.tgz#3496232f1fa36dbce74aae8ca451a8ba43e1e275"
+ember-popper@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/ember-popper/-/ember-popper-0.8.3.tgz#547ec0e8d810805bd65bce7556f0a3377cb9730c"
   dependencies:
-    "@ember-decorators/argument" "^0.8.3"
+    "@ember-decorators/argument" "^0.8.10"
+    "@ember-decorators/babel-transforms" "^0.1.1"
     babel-eslint "^8.0.3"
     babel6-plugin-strip-class-callcheck "^6.0.0"
     broccoli-funnel "^2.0.0"
@@ -3003,7 +2987,7 @@ ember-popper@^0.8.0:
     ember-cli-version-checker "^2.1.0"
     ember-compatibility-helpers "^0.1.3"
     ember-decorators "^1.3.2"
-    ember-legacy-class-transform "^0.1.4"
+    ember-legacy-class-shim "^1.0.0"
     ember-raf-scheduler "^0.1.0"
     fastboot-transform "^0.1.0"
     popper.js "^1.12.9"


### PR DESCRIPTION
After some recent research we've been able to make the legacy class transforms and @argument more efficient overall, and more inline with the future version of ES classes. This PR bumps the dependencies to the most recent releases.