### PR TITLE
Add support for user-defined popper modifiers

### DIFF
--- a/addon/components/-private/base-pop-menu.js
+++ b/addon/components/-private/base-pop-menu.js
@@ -1,10 +1,10 @@
 import Component from '@ember/component';
-import { computed } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import { run } from '@ember/runloop';
 import { assert } from '@ember/debug';
 
 import { action } from 'ember-decorators/object';
+import { computed } from 'ember-decorators/object';
 
 import { argument } from '@ember-decorators/argument';
 import { type } from '@ember-decorators/argument/type';
@@ -113,17 +113,18 @@ export default class BasePopMenuComponent extends Component {
   };
 
   /**
-   * Combined set of default modifiers and user-provided modifiers. Overwrites default
-   * modifiers with user-provided ones if there is overlap.
-   */
-  _popperModifiers = computed('popperModifiers', function() {
-    return Object.assign({}, this._defaultPopperModifiers, this.get('popperModifiers'));
-  });
-
-  /**
    * Root element that has attached event listeners for body close action
    */
   _rootElement = null;
+
+  /**
+   * Combined set of default modifiers and user-provided modifiers. Overwrites default
+   * modifiers with user-provided ones if there is overlap.
+   */
+  @computed('popperModifiers')
+  get _popperModifiers() {
+    return Object.assign({}, this._defaultPopperModifiers, this.get('popperModifiers'));
+  }
 
   constructor() {
     super();

--- a/addon/components/-private/base-pop-menu.js
+++ b/addon/components/-private/base-pop-menu.js
@@ -7,7 +7,7 @@ import { action } from 'ember-decorators/object';
 import { computed } from 'ember-decorators/object';
 
 import { argument } from '@ember-decorators/argument';
-import { type } from '@ember-decorators/argument/type';
+import { type, unionOf } from '@ember-decorators/argument/type';
 import { immutable } from '@ember-decorators/argument/validation';
 
 import { scheduler as raf } from 'ember-raf-scheduler';
@@ -25,6 +25,19 @@ function closest(node, selector) {
 
   return null;
 }
+
+/**
+ * Modifiers to the popper to set it's default behavior
+ */
+const DEFAULT_POPPER_MODIFIERS = {
+  flip: {
+    boundariesElement: 'viewport'
+  },
+
+  preventOverflow: {
+    boundariesElement: 'window'
+  }
+};
 
 /**
  * Base class which ice-popover, ice-tooltip, and ice-dropdown all inherit from.
@@ -73,8 +86,8 @@ export default class BasePopMenuComponent extends Component {
    * Documentation for popper modifiers can be found at https://popper.js.org/popper-documentation.html#modifiers
    */
   @argument
-  @type('object')
-  popperModifiers = {};
+  @type(unionOf(null, 'object'))
+  popperModifiers = null;
 
   // ----- Private Variables -----
 
@@ -100,19 +113,6 @@ export default class BasePopMenuComponent extends Component {
   _popperClass = '';
 
   /**
-   * Modifiers to the popper to set it's default behavior
-   */
-  _defaultPopperModifiers = {
-    flip: {
-      boundariesElement: 'viewport'
-    },
-
-    preventOverflow: {
-      boundariesElement: 'window'
-    }
-  };
-
-  /**
    * Root element that has attached event listeners for body close action
    */
   _rootElement = null;
@@ -123,7 +123,7 @@ export default class BasePopMenuComponent extends Component {
    */
   @computed('popperModifiers')
   get _popperModifiers() {
-    return Object.assign({}, this._defaultPopperModifiers, this.get('popperModifiers'));
+    return Object.assign({}, DEFAULT_POPPER_MODIFIERS, this.get('popperModifiers'));
   }
 
   constructor() {

--- a/addon/components/-private/base-pop-menu.js
+++ b/addon/components/-private/base-pop-menu.js
@@ -1,4 +1,5 @@
 import Component from '@ember/component';
+import { computed } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import { run } from '@ember/runloop';
 import { assert } from '@ember/debug';
@@ -115,7 +116,9 @@ export default class BasePopMenuComponent extends Component {
    * Combined set of default modifiers and user-provided modifiers. Overwrites default
    * modifiers with user-provided ones if there is overlap.
    */
-  _popperModifiers = null;
+  _popperModifiers = computed('popperModifiers', function() {
+    return Object.assign({}, this._defaultPopperModifiers, this.get('popperModifiers'));
+  });
 
   /**
    * Root element that has attached event listeners for body close action
@@ -189,8 +192,6 @@ export default class BasePopMenuComponent extends Component {
     // `isOpen` to true, and only _then_ setting `isShowing` to true, triggering the
     // CSS transition
     run(() => this.set('isOpen', true));
-    let combinedModifiers = Object.assign({}, this._defaultPopperModifiers, this.get('popperModifiers'));
-    this.set('_popperModifiers', combinedModifiers);
 
     this._rootElement.addEventListener('mouseup', this._handleBodyClick);
   }

--- a/addon/components/-private/base-pop-menu.js
+++ b/addon/components/-private/base-pop-menu.js
@@ -67,6 +67,14 @@ export default class BasePopMenuComponent extends Component {
   @type('string')
   rootElementSelector = '.ember-application';
 
+  /**
+   * User-provided modifiers to the popper.
+   * Documentation for popper modifiers can be found at https://popper.js.org/popper-documentation.html#modifiers
+   */
+  @argument
+  @type('object')
+  popperModifiers = {};
+
   // ----- Private Variables -----
 
   /**
@@ -93,7 +101,7 @@ export default class BasePopMenuComponent extends Component {
   /**
    * Modifiers to the popper to set it's default behavior
    */
-  _popperModifiers = {
+  _defaultPopperModifiers = {
     flip: {
       boundariesElement: 'viewport'
     },
@@ -102,6 +110,12 @@ export default class BasePopMenuComponent extends Component {
       boundariesElement: 'window'
     }
   };
+
+  /**
+   * Combined set of default modifiers and user-provided modifiers. Overwrites default
+   * modifiers with user-provided ones if there is overlap.
+   */
+  _popperModifiers = null;
 
   /**
    * Root element that has attached event listeners for body close action
@@ -175,6 +189,8 @@ export default class BasePopMenuComponent extends Component {
     // `isOpen` to true, and only _then_ setting `isShowing` to true, triggering the
     // CSS transition
     run(() => this.set('isOpen', true));
+    let combinedModifiers = Object.assign({}, this._defaultPopperModifiers, this.get('popperModifiers'));
+    this.set('_popperModifiers', combinedModifiers);
 
     this._rootElement.addEventListener('mouseup', this._handleBodyClick);
   }

--- a/tests/integration/components/ice-popover-test.js
+++ b/tests/integration/components/ice-popover-test.js
@@ -1,9 +1,8 @@
-import { moduleForComponent, module, test } from 'ember-qunit';
+import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
 import PageObject, { clickable, hasClass, triggerable } from 'ember-classy-page-object';
 
-import IcePopover from '@addepar/ice-pop/components/ice-popover';
 import IcePopoverPage from '@addepar/ice-pop/test-support/pages/ice-popover';
 
 const PopoverHelper = IcePopoverPage.extend({ scope: '[data-test-popover]' });

--- a/tests/integration/components/ice-popover-test.js
+++ b/tests/integration/components/ice-popover-test.js
@@ -315,3 +315,36 @@ test('First item autofocuses when opened by keyboard only', async function(asser
   assert.ok(popover.isOpen, 'popover rendered on click');
   assert.ok(!popover.content.buttonWithFocus.isPresent, 'first button does not have focus');
 });
+
+moduleForComponent('ice-popover', 'Unit | Component | ice-popover', {
+  unit: true
+});
+
+test('popper modifiers are customizable', function(assert) {
+  assert.expect(2);
+
+  let popover = this.subject();
+  assert.deepEqual(
+    popover.get('_popperModifiers'),
+    {
+      flip: { boundariesElement: 'viewport' },
+      preventOverflow: { boundariesElement: 'window' }
+    },
+    'Default modifiers are correct'
+  );
+
+  popover.set('popperModifiers', {
+    flip: { boundariesElement: 'overrideValue' },
+    newProperty: 'newValue'
+  });
+
+  assert.deepEqual(
+    popover.get('_popperModifiers'),
+    {
+      flip: { boundariesElement: 'overrideValue' },
+      preventOverflow: { boundariesElement: 'window' },
+      newProperty: 'newValue'
+    },
+    'Merging of modifiers is correct'
+  );
+});

--- a/tests/integration/components/ice-popover-test.js
+++ b/tests/integration/components/ice-popover-test.js
@@ -323,7 +323,7 @@ moduleForComponent('ice-popover', 'Unit | Component | ice-popover', {
 test('popper modifiers are customizable', function(assert) {
   assert.expect(2);
 
-  let popover = this.subject();
+  let popover = this.subject({});
   assert.deepEqual(
     popover.get('_popperModifiers'),
     {

--- a/tests/integration/components/ice-popover-test.js
+++ b/tests/integration/components/ice-popover-test.js
@@ -317,15 +317,14 @@ test('First item autofocuses when opened by keyboard only', async function(asser
   assert.ok(!popover.content.buttonWithFocus.isPresent, 'first button does not have focus');
 });
 
-module('Unit | Component | ice-popover');
+moduleForComponent('ice-popover', 'Unit | Component | ice-popover', {
+  unit: true
+});
 
 test('popper modifiers are customizable', function(assert) {
   assert.expect(2);
 
-  let popover = IcePopover.create({
-    renderer: true
-  });
-
+  let popover = this.subject({});
   assert.deepEqual(
     popover.get('_popperModifiers'),
     {

--- a/tests/integration/components/ice-popover-test.js
+++ b/tests/integration/components/ice-popover-test.js
@@ -1,8 +1,9 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { moduleForComponent, module, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
 import PageObject, { clickable, hasClass, triggerable } from 'ember-classy-page-object';
 
+import IcePopover from '@addepar/ice-pop/components/ice-popover';
 import IcePopoverPage from '@addepar/ice-pop/test-support/pages/ice-popover';
 
 const PopoverHelper = IcePopoverPage.extend({ scope: '[data-test-popover]' });
@@ -316,14 +317,15 @@ test('First item autofocuses when opened by keyboard only', async function(asser
   assert.ok(!popover.content.buttonWithFocus.isPresent, 'first button does not have focus');
 });
 
-moduleForComponent('ice-popover', 'Unit | Component | ice-popover', {
-  unit: true
-});
+module('Unit | Component | ice-popover');
 
 test('popper modifiers are customizable', function(assert) {
   assert.expect(2);
 
-  let popover = this.subject({});
+  let popover = IcePopover.create({
+    renderer: true
+  });
+
   assert.deepEqual(
     popover.get('_popperModifiers'),
     {


### PR DESCRIPTION
When using `ice-popover` inside of a scrollable list, I found myself needing to adjust some of the modifiers that get passed into the Popper itself. Ember-popper [supports user-defined modifiers](https://github.com/kybishop/ember-popper/blob/master/addon/components/ember-popper-base.js#L26), but with ice-pop we just use a private variable of defined values.

This changeset introduces a new argument `popperModifiers` which can be defined by the user. It merges the previous default modifiers with whatever the user has defined (with overwrite priority going to the publicly-defined modifiers).

Not sure if this is the approach we would want to take, but adding an argument for overriding modifiers would be great, considering they already are supported in ember-popper.