### PR TITLE
[TESTS] Upgrade ember-cli-shims for ember-1.11 scenario

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -7,11 +7,11 @@ module.exports = {
       bower: {
         dependencies: {
           'ember': '~1.11.0',
-          'ember-cli-shims': 'ember-cli/ember-cli-shims#0.0.3'
+          'ember-cli-shims': 'ember-cli/ember-cli-shims#0.0.5'
         },
         resolutions: {
           'ember': '~1.11.0',
-          'ember-cli-shims': '0.0.3'
+          'ember-cli-shims': '0.0.5'
         }
       },
       npm: {


### PR DESCRIPTION
There is an undefined reference to `DS` in `ember-cli-shims` < 0.0.5 paired with ember-1.11, which causes the ember-1.11 scenario to fail on ice-pop master. This upgrades the `ember-cli-shims` version to 0.0.5 for the 1.11 scenario. I did not find root cause on why this regressed; there must be another package that had previously defined `DS` that was since upgraded. Seeing as there was no obvious reason to pair 0.0.3 with 1.11, this just upgrades the shims version used for 1.11 scenario to 0.0.5.